### PR TITLE
feat: auto-detect runner labels to match GitHub-hosted conventions

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,24 +18,37 @@ idle_timeout: 15m
 
 runner_sets:
   # macOS runners via Tart VMs (Apple Silicon only)
+  # When labels is omitted, defaults are auto-detected from the platform:
+  #   self-hosted, macos, arm64, macos-latest, macos-15, macos-14
   - name: efr-macos-arm64
     backend: tart
     image: ghcr.io/cirruslabs/macos-sequoia-base:latest
-    labels: [self-hosted, macOS, ARM64]
     max_runners: 2
+    # extra_labels: [gpu]
+    # version_aliases: [macos-15]
 
   # Linux ARM64 runners via Docker (DinD image includes Docker daemon)
+  # Auto-detected defaults for linux/arm64:
+  #   self-hosted, linux, arm64, ubuntu-latest-arm, ubuntu-24.04-arm, ubuntu-22.04-arm
   - name: efr-linux-arm64
     backend: docker
     image: ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner-dind:latest
-    labels: [self-hosted, Linux, ARM64]
     max_runners: 4
     platform: linux/arm64
 
   # Linux AMD64 runners via Docker (Rosetta 2 on Apple Silicon)
+  # Auto-detected defaults for linux/amd64:
+  #   self-hosted, linux, x64, ubuntu-latest, ubuntu-24.04, ubuntu-22.04
   - name: efr-linux-amd64
     backend: docker
     image: ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner-dind:latest
-    labels: [self-hosted, Linux, X64]
     max_runners: 4
     platform: linux/amd64
+
+  # Explicit labels override auto-detection entirely:
+  # - name: efr-custom
+  #   backend: docker
+  #   image: my-custom-image:latest
+  #   labels: [self-hosted, custom-label]
+  #   max_runners: 2
+  #   platform: linux/amd64

--- a/config/config.go
+++ b/config/config.go
@@ -40,9 +40,21 @@ type RunnerSetConfig struct {
 	Name       string   `yaml:"name"`
 	Backend    string   `yaml:"backend"`
 	Image      string   `yaml:"image"`
-	Labels     []string `yaml:"labels"`
 	MaxRunners int      `yaml:"max_runners"`
 	Platform   string   `yaml:"platform"`
+
+	// Labels overrides all auto-detected labels. When set, only these
+	// labels (plus the scale set name) are registered.
+	Labels []string `yaml:"labels"`
+
+	// ExtraLabels are appended to the auto-detected labels (ignored when
+	// Labels is explicitly set).
+	ExtraLabels []string `yaml:"extra_labels"`
+
+	// VersionAliases overrides the default version alias labels
+	// (e.g. "ubuntu-24.04", "macos-15"). Set to an empty list to disable.
+	// When nil/omitted, defaults are used based on the detected platform.
+	VersionAliases *[]string `yaml:"version_aliases"`
 }
 
 // AuthMode returns which authentication method is configured.
@@ -150,8 +162,12 @@ func (c *Config) RedactedSlogAttrs() []any {
 			prefix+"backend", rs.Backend,
 			prefix+"image", rs.Image,
 			prefix+"labels", rs.Labels,
+			prefix+"extra_labels", rs.ExtraLabels,
 			prefix+"max_runners", rs.MaxRunners,
 		)
+		if rs.VersionAliases != nil {
+			attrs = append(attrs, prefix+"version_aliases", *rs.VersionAliases)
+		}
 		if rs.Platform != "" {
 			attrs = append(attrs, prefix+"platform", rs.Platform)
 		}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/boring-design/elastic-fruit-runner/config"
 	"github.com/boring-design/elastic-fruit-runner/internal/backend"
+	"github.com/boring-design/elastic-fruit-runner/internal/labels"
 )
 
 var tracer = otel.Tracer("github.com/boring-design/elastic-fruit-runner/internal/controller")
@@ -70,9 +71,17 @@ func (d *ScaleSetController) Run(ctx context.Context) error {
 	}
 	d.logger.Info("runner group resolved", "id", group.ID, "name", group.Name)
 
-	desiredLabels := make([]scaleset.Label, 0, len(d.rsCfg.Labels)+1)
-	desiredLabels = append(desiredLabels, scaleset.Label{Name: d.rsCfg.Name})
-	for _, l := range d.rsCfg.Labels {
+	detectedOS, detectedArch := labels.DetectPlatform(d.rsCfg.Platform)
+	var opts []labels.Option
+	if d.rsCfg.VersionAliases != nil {
+		opts = append(opts, labels.WithVersionAliases(*d.rsCfg.VersionAliases))
+	}
+	resolvedLabels := labels.ResolveLabels(
+		d.rsCfg.Name, d.rsCfg.Labels, d.rsCfg.ExtraLabels,
+		detectedOS, detectedArch, opts...,
+	)
+	desiredLabels := make([]scaleset.Label, 0, len(resolvedLabels))
+	for _, l := range resolvedLabels {
 		desiredLabels = append(desiredLabels, scaleset.Label{Name: l})
 	}
 

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,0 +1,123 @@
+package labels
+
+import (
+	"runtime"
+	"strings"
+)
+
+// DetectPlatform returns the normalized OS and architecture from a platform
+// string (e.g. "linux/arm64"). If platform is empty, it falls back to the
+// current runtime.
+func DetectPlatform(platform string) (os, arch string) {
+	if platform != "" {
+		parts := strings.SplitN(platform, "/", 2)
+		if len(parts) == 2 {
+			os = strings.ToLower(parts[0])
+			arch = normalizeArch(parts[1])
+			return os, arch
+		}
+	}
+	return runtime.GOOS, normalizeArch(runtime.GOARCH)
+}
+
+// normalizeArch maps Go-style architecture names to GitHub runner conventions.
+func normalizeArch(arch string) string {
+	switch strings.ToLower(arch) {
+	case "amd64", "x86_64", "x64":
+		return "x64"
+	case "arm64", "aarch64":
+		return "arm64"
+	default:
+		return strings.ToLower(arch)
+	}
+}
+
+// DefaultLabels returns the base labels for a given OS/arch combination,
+// following GitHub-hosted runner naming conventions with lowercase.
+func DefaultLabels(os, arch string) []string {
+	osLabel := strings.ToLower(os)
+	if osLabel == "darwin" {
+		osLabel = "macos"
+	}
+	return []string{"self-hosted", osLabel, arch}
+}
+
+// DefaultVersionAliases returns the default version alias labels for a
+// given OS/arch, mirroring GitHub-hosted runner label names.
+func DefaultVersionAliases(os, arch string) []string {
+	os = strings.ToLower(os)
+	switch {
+	case os == "linux" && arch == "x64":
+		return []string{"ubuntu-latest", "ubuntu-24.04", "ubuntu-22.04"}
+	case os == "linux" && arch == "arm64":
+		return []string{"ubuntu-latest-arm", "ubuntu-24.04-arm", "ubuntu-22.04-arm"}
+	case (os == "darwin" || os == "macos") && arch == "arm64":
+		return []string{"macos-latest", "macos-15", "macos-14"}
+	default:
+		return nil
+	}
+}
+
+// Option configures label resolution behavior.
+type Option func(*resolveOptions)
+
+type resolveOptions struct {
+	versionAliases *[]string
+}
+
+// WithVersionAliases overrides the default version aliases. Pass an empty
+// slice to disable version alias labels entirely.
+func WithVersionAliases(aliases []string) Option {
+	return func(o *resolveOptions) {
+		o.versionAliases = &aliases
+	}
+}
+
+// ResolveLabels computes the final label list for a runner scale set.
+//
+// If explicit is non-empty, it is used as-is (prepended with scaleSetName).
+// Otherwise, labels are auto-generated from os/arch with version aliases and
+// extra labels appended. Duplicates are removed while preserving order.
+func ResolveLabels(scaleSetName string, explicit []string, extra []string, os, arch string, opts ...Option) []string {
+	var o resolveOptions
+	for _, fn := range opts {
+		fn(&o)
+	}
+
+	result := []string{scaleSetName}
+
+	if len(explicit) > 0 {
+		result = append(result, explicit...)
+		return result
+	}
+
+	result = append(result, DefaultLabels(os, arch)...)
+
+	var aliases []string
+	if o.versionAliases != nil {
+		aliases = *o.versionAliases
+	} else {
+		aliases = DefaultVersionAliases(os, arch)
+	}
+	result = append(result, aliases...)
+
+	result = appendDedup(result, extra)
+
+	return result
+}
+
+// appendDedup appends items from extra to base, skipping any that already
+// exist in base. Preserves order of base followed by new items from extra.
+func appendDedup(base, extra []string) []string {
+	seen := make(map[string]struct{}, len(base))
+	for _, l := range base {
+		seen[l] = struct{}{}
+	}
+	for _, l := range extra {
+		if _, ok := seen[l]; !ok {
+			base = append(base, l)
+			seen[l] = struct{}{}
+		}
+	}
+	return base
+}

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -1,0 +1,218 @@
+package labels
+
+import (
+	"testing"
+)
+
+func TestDetectPlatform_FromExplicitPlatformField(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform string
+		wantOS   string
+		wantArch string
+	}{
+		{"linux/amd64", "linux/amd64", "linux", "x64"},
+		{"linux/arm64", "linux/arm64", "linux", "arm64"},
+		{"linux/x64 alias", "linux/x64", "linux", "x64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os, arch := DetectPlatform(tt.platform)
+			if os != tt.wantOS {
+				t.Errorf("DetectPlatform(%q) os = %q, want %q", tt.platform, os, tt.wantOS)
+			}
+			if arch != tt.wantArch {
+				t.Errorf("DetectPlatform(%q) arch = %q, want %q", tt.platform, arch, tt.wantArch)
+			}
+		})
+	}
+}
+
+func TestDetectPlatform_EmptyFallsBackToRuntime(t *testing.T) {
+	os, arch := DetectPlatform("")
+	if os == "" || arch == "" {
+		t.Errorf("DetectPlatform(\"\") returned empty os=%q or arch=%q", os, arch)
+	}
+}
+
+func TestDefaultLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		os       string
+		arch     string
+		expected []string
+	}{
+		{
+			"linux x64",
+			"linux", "x64",
+			[]string{"self-hosted", "linux", "x64"},
+		},
+		{
+			"linux arm64",
+			"linux", "arm64",
+			[]string{"self-hosted", "linux", "arm64"},
+		},
+		{
+			"macos arm64",
+			"darwin", "arm64",
+			[]string{"self-hosted", "macos", "arm64"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultLabels(tt.os, tt.arch)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("DefaultLabels(%q, %q) = %v, want %v", tt.os, tt.arch, got, tt.expected)
+			}
+			for i, l := range got {
+				if l != tt.expected[i] {
+					t.Errorf("DefaultLabels(%q, %q)[%d] = %q, want %q", tt.os, tt.arch, i, l, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultVersionAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		os       string
+		arch     string
+		expected []string
+	}{
+		{
+			"linux x64",
+			"linux", "x64",
+			[]string{"ubuntu-latest", "ubuntu-24.04", "ubuntu-22.04"},
+		},
+		{
+			"linux arm64",
+			"linux", "arm64",
+			[]string{"ubuntu-latest-arm", "ubuntu-24.04-arm", "ubuntu-22.04-arm"},
+		},
+		{
+			"macos arm64",
+			"darwin", "arm64",
+			[]string{"macos-latest", "macos-15", "macos-14"},
+		},
+		{
+			"unknown platform",
+			"freebsd", "amd64",
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultVersionAliases(tt.os, tt.arch)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("DefaultVersionAliases(%q, %q) = %v, want %v", tt.os, tt.arch, got, tt.expected)
+			}
+			for i, l := range got {
+				if l != tt.expected[i] {
+					t.Errorf("DefaultVersionAliases(%q, %q)[%d] = %q, want %q", tt.os, tt.arch, i, l, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveLabels_ExplicitOverride(t *testing.T) {
+	got := ResolveLabels("my-set", []string{"custom-a", "custom-b"}, nil, "", "")
+	expected := []string{"my-set", "custom-a", "custom-b"}
+	if len(got) != len(expected) {
+		t.Fatalf("ResolveLabels explicit = %v, want %v", got, expected)
+	}
+	for i, l := range got {
+		if l != expected[i] {
+			t.Errorf("ResolveLabels explicit[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}
+
+func TestResolveLabels_AutoDetectWithVersionAliases(t *testing.T) {
+	got := ResolveLabels("my-set", nil, nil, "linux", "x64")
+	expected := []string{
+		"my-set",
+		"self-hosted", "linux", "x64",
+		"ubuntu-latest", "ubuntu-24.04", "ubuntu-22.04",
+	}
+	if len(got) != len(expected) {
+		t.Fatalf("ResolveLabels auto = %v, want %v", got, expected)
+	}
+	for i, l := range got {
+		if l != expected[i] {
+			t.Errorf("ResolveLabels auto[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}
+
+func TestResolveLabels_AutoDetectWithExtraLabels(t *testing.T) {
+	got := ResolveLabels("my-set", nil, []string{"gpu", "custom"}, "linux", "x64")
+	expected := []string{
+		"my-set",
+		"self-hosted", "linux", "x64",
+		"ubuntu-latest", "ubuntu-24.04", "ubuntu-22.04",
+		"gpu", "custom",
+	}
+	if len(got) != len(expected) {
+		t.Fatalf("ResolveLabels extra = %v, want %v", got, expected)
+	}
+	for i, l := range got {
+		if l != expected[i] {
+			t.Errorf("ResolveLabels extra[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}
+
+func TestResolveLabels_ExplicitVersionAliases(t *testing.T) {
+	got := ResolveLabels("my-set", nil, nil, "linux", "x64",
+		WithVersionAliases([]string{"ubuntu-24.04"}))
+	expected := []string{
+		"my-set",
+		"self-hosted", "linux", "x64",
+		"ubuntu-24.04",
+	}
+	if len(got) != len(expected) {
+		t.Fatalf("ResolveLabels version aliases = %v, want %v", got, expected)
+	}
+	for i, l := range got {
+		if l != expected[i] {
+			t.Errorf("ResolveLabels version aliases[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}
+
+func TestResolveLabels_EmptyVersionAliasesDisablesDefaults(t *testing.T) {
+	got := ResolveLabels("my-set", nil, nil, "linux", "x64",
+		WithVersionAliases([]string{}))
+	expected := []string{
+		"my-set",
+		"self-hosted", "linux", "x64",
+	}
+	if len(got) != len(expected) {
+		t.Fatalf("ResolveLabels no aliases = %v, want %v", got, expected)
+	}
+	for i, l := range got {
+		if l != expected[i] {
+			t.Errorf("ResolveLabels no aliases[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}
+
+func TestResolveLabels_DeduplicatesLabels(t *testing.T) {
+	got := ResolveLabels("my-set", nil, []string{"self-hosted", "linux", "custom"}, "linux", "x64",
+		WithVersionAliases([]string{}))
+	expected := []string{
+		"my-set",
+		"self-hosted", "linux", "x64",
+		"custom",
+	}
+	if len(got) != len(expected) {
+		t.Fatalf("ResolveLabels dedup = %v, want %v", got, expected)
+	}
+	for i, l := range got {
+		if l != expected[i] {
+			t.Errorf("ResolveLabels dedup[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Auto-detect OS/arch from `platform` field (or runtime) and generate GitHub-hosted-runner-compatible labels
- Default labels use **lowercase** (`self-hosted`, `linux`, `x64`, `macos`, `arm64`)
- Include version alias labels by default (`ubuntu-latest`, `ubuntu-24.04`, `macos-15`, etc.)
- New `extra_labels` config field to append custom labels on top of auto-detected ones
- New `version_aliases` config field to override or disable default version aliases
- Existing `labels` field still works as full override for backwards compatibility

Closes #7

## Test plan

- [x] Unit tests for `internal/labels` package covering all platforms and config combinations
- [ ] Manual test: remove `labels` from config, verify auto-detected labels are registered correctly
- [ ] Manual test: set explicit `labels`, verify they override auto-detection
- [ ] Manual test: use `extra_labels` and `version_aliases` to customize