### PR TITLE
chore: pin macOS VM image to macos-tahoe-xcode:26.3

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Flat `Config` struct populated from `flag` + `os.Getenv`. Flags take precedence 
 | `--url` | `GITHUB_CONFIG_URL` | — | e.g. `https://github.com/myorg` |
 | `--runner-group` | `GITHUB_RUNNER_GROUP` | `Default` | |
 | `--scale-set-name` | `SCALE_SET_NAME` | `elastic-fruit-runner` | |
-| `--vm-image` | `TART_VM_IMAGE` | cirruslabs sequoia base | Base image to clone |
+| `--vm-image` | `TART_VM_IMAGE` | cirruslabs tahoe xcode | Base image to clone |
 | `--max-runners` | — | `2` | Apple EULA caps macOS VMs at 2 per host |
 
 ### `internal/daemon/daemon.go`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ github:
 runner_sets:
   - name: efr-macos-arm64
     backend: tart
-    image: ghcr.io/cirruslabs/macos-sequoia-base:latest
+    image: ghcr.io/cirruslabs/macos-tahoe-xcode:26.3
     labels: [self-hosted, macOS, ARM64]
     max_runners: 2
 EOF

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,7 +20,7 @@ runner_sets:
   # macOS runners via Tart VMs (Apple Silicon only)
   - name: efr-macos-arm64
     backend: tart
-    image: ghcr.io/cirruslabs/macos-sequoia-base:latest
+    image: ghcr.io/cirruslabs/macos-tahoe-xcode:26.3
     labels: [self-hosted, macOS, ARM64]
     max_runners: 2
 

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -37,7 +37,7 @@ github:
 runner_sets:
   - name: efr-macos-arm64
     backend: tart
-    image: ghcr.io/cirruslabs/macos-sequoia-base:latest
+    image: ghcr.io/cirruslabs/macos-tahoe-xcode:26.3
     labels: [self-hosted, macOS, ARM64]
     max_runners: 2
 ```

--- a/internal/backend/tart.go
+++ b/internal/backend/tart.go
@@ -15,7 +15,7 @@ import (
 )
 
 // isRemoteImage returns true if the image looks like a registry reference
-// (e.g. "ghcr.io/cirruslabs/macos-sequoia-base:latest") rather than a local
+// (e.g. "ghcr.io/cirruslabs/macos-tahoe-xcode:26.3") rather than a local
 // VM name (e.g. "gha-runner-sequoia-xcode-16").
 func isRemoteImage(image string) bool {
 	return strings.Contains(image, "/")


### PR DESCRIPTION
## Summary
- Switch default macOS VM image from `ghcr.io/cirruslabs/macos-sequoia-base:latest` to `ghcr.io/cirruslabs/macos-tahoe-xcode:26.3`
- Pinning to a specific stable tag avoids pulling potentially broken `latest` builds
- Updated across config example, README, install docs, architecture docs, and code comments

## Test plan
- [ ] Verify `tart pull ghcr.io/cirruslabs/macos-tahoe-xcode:26.3` succeeds
- [ ] Run a test workflow using the new image