### PR TITLE
feat: add Makefile for common development tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Build output
 /elastic-fruit-runner
+/output/
 github-app-key.pem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,12 @@
 
 ## Build
 
-- Build: `make build`
+- Build: `make build` (output in `output/`)
 - Test: `make test`
 - Lint: `make lint`
-- CI checks: `make ci`
+- Quick local check: `make check` (fmt + vet + build)
+- Full CI checks: `make ci`
+- Show all targets: `make help`
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run unit-test test fmt fmt-check vet lint ci tidy prek-all prek-install
+.PHONY: build run unit-test test fmt fmt-check vet lint check ci tidy prek-all prek-install help
 
 # Build the CLI binary
 build:
@@ -28,6 +28,9 @@ vet:
 lint:
 	golangci-lint run
 
+# Run quick local checks before committing (format, vet, build)
+check: fmt vet build
+
 # Run all CI checks (same as pre-commit)
 ci: fmt-check vet build lint unit-test
 
@@ -42,3 +45,27 @@ prek-all:
 # Install prek git hooks
 prek-install:
 	prek install
+
+# Show available targets
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Development:"
+	@echo "  build       Build the CLI binary to output/"
+	@echo "  fmt         Format Go code"
+	@echo "  vet         Run go vet"
+	@echo "  lint        Run golangci-lint"
+	@echo "  check       Run fmt + vet + build (quick local check)"
+	@echo "  tidy        Tidy go modules"
+	@echo ""
+	@echo "Testing:"
+	@echo "  test        Run all tests"
+	@echo "  unit-test   Run unit tests"
+	@echo ""
+	@echo "CI:"
+	@echo "  ci          Run all CI checks (fmt-check + vet + build + lint + unit-test)"
+	@echo "  fmt-check   Check formatting without modifying files"
+	@echo ""
+	@echo "Hooks:"
+	@echo "  prek-install  Install prek git hooks"
+	@echo "  prek-all      Run prek on all files"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for details.
 
 ---
 
+## Development
+
+```sh
+# Show all available targets
+make help
+
+# Build the binary (output in output/)
+make build
+
+# Run tests
+make test
+
+# Quick local check before committing (format, vet, build)
+make check
+
+# Run full CI checks (format-check, vet, build, lint, tests)
+make ci
+```
+
+---
+
 ## Roadmap
 
 - [x] Linux arm64 runner (Docker)


### PR DESCRIPTION
## Summary
- Add a Makefile with targets for build, test, fmt, vet, lint, ci, tidy, and prek hooks, modeled after the lapp project
- Update CLAUDE.md to reference Makefile commands instead of raw go commands

## Test plan
- [ ] Verify `make build` produces binary at `output/elastic-fruit-runner`
- [ ] Verify `make test` runs all tests
- [ ] Verify `make lint` runs golangci-lint
- [ ] Verify `make ci` runs the full check suite