### PR TITLE
test: add tart VM lifecycle integration tests

### DIFF
--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -78,7 +78,6 @@ jobs:
           security set-keychain-settings -lut 21600 "$tart_keychain"
           security list-keychains -d user -s "$tart_keychain"
           security default-keychain -s "$tart_keychain"
-          security login-keychain -s "$tart_keychain"
 
           if sudo -n true 2>/dev/null; then
             sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.InternetSharing.default.plist bootpd -dict DHCPLeaseTimeSecs -int 600

--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -71,9 +71,14 @@ jobs:
           "$brew_prefix/bin/sshpass" -V
           "$brew_prefix/bin/gpg" --version
 
-          security create-keychain -p '' login.keychain || true
-          security unlock-keychain -p '' login.keychain
-          security login-keychain -s login.keychain
+          tart_keychain="$RUNNER_TEMP/tart-login.keychain"
+          rm -f "$tart_keychain" "$tart_keychain-db"
+          security create-keychain -p '' "$tart_keychain"
+          security unlock-keychain -p '' "$tart_keychain"
+          security set-keychain-settings -lut 21600 "$tart_keychain"
+          security list-keychains -d user -s "$tart_keychain"
+          security default-keychain -s "$tart_keychain"
+          security login-keychain -s "$tart_keychain"
 
           if sudo -n true 2>/dev/null; then
             sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.InternetSharing.default.plist bootpd -dict DHCPLeaseTimeSecs -int 600

--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -54,10 +54,22 @@ jobs:
       - name: Install Tart integration dependencies
         if: matrix.name == 'Tart'
         run: |
-          brew install cirruslabs/cli/tart cirruslabs/cli/sshpass gnupg
-          tart --version
-          sshpass -V
-          gpg --version
+          if [ -x /opt/homebrew/bin/brew ]; then
+            brew_bin=/opt/homebrew/bin/brew
+          elif [ -x /usr/local/bin/brew ]; then
+            brew_bin=/usr/local/bin/brew
+          else
+            echo "::error::Homebrew is required for Tart integration tests"
+            exit 1
+          fi
+
+          brew_prefix="$("$brew_bin" --prefix)"
+          echo "$brew_prefix/bin" >> "$GITHUB_PATH"
+
+          "$brew_bin" install cirruslabs/cli/tart cirruslabs/cli/sshpass gnupg
+          "$brew_prefix/bin/tart" --version
+          "$brew_prefix/bin/sshpass" -V
+          "$brew_prefix/bin/gpg" --version
 
       - name: Write GitHub App private key
         if: matrix.needs-app-key

--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -14,7 +14,7 @@ jobs:
   integration-test:
     name: Integration Test (${{ matrix.name }})
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +88,7 @@ jobs:
           EFR_TEST_APP_INSTALLATION_ID: ${{ secrets.EFR_TEST_APP_INSTALLATION_ID }}
           EFR_TEST_APP_PRIVATE_KEY_PATH: ${{ matrix.needs-app-key && '/tmp/efr-test-app-key.pem' || '' }}
           EFR_TEST_FEATURES: ${{ matrix.features }}
-        run: go test -tags=integration -count=1 -v -timeout=25m -coverpkg=./... -coverprofile=coverage.out ./test/integration/
+        run: go test -tags=integration -count=1 -v -timeout=55m -coverpkg=./... -coverprofile=coverage.out ./test/integration/
 
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -25,7 +25,7 @@ jobs:
             needs-app-key: false
           - name: GitHub App
             runs-on: [self-hosted, linux, arm64]
-            features: ../../features/management
+            features: ../../features/config,../../features/binpath,../../features/jobstore,../../features/vitals,../../features/management
             needs-app-key: true
           - name: Tart
             runs-on: [self-hosted, macos, arm64]

--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -13,19 +13,22 @@ permissions:
 jobs:
   integration-test:
     name: Integration Test (${{ matrix.name }})
-    runs-on: [self-hosted, linux, arm64]
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: PAT
+            runs-on: [self-hosted, linux, arm64]
             features: ../../features/config,../../features/binpath,../../features/jobstore,../../features/vitals,../../features/management
             needs-app-key: false
           - name: GitHub App
+            runs-on: [self-hosted, linux, arm64]
             features: ../../features/management
             needs-app-key: true
           - name: Tart
+            runs-on: [self-hosted, macos, arm64]
             features: ../../features/tart
             needs-app-key: false
     steps:

--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -71,6 +71,17 @@ jobs:
           "$brew_prefix/bin/sshpass" -V
           "$brew_prefix/bin/gpg" --version
 
+          security create-keychain -p '' login.keychain || true
+          security unlock-keychain -p '' login.keychain
+          security login-keychain -s login.keychain
+
+          if sudo -n true 2>/dev/null; then
+            sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.InternetSharing.default.plist bootpd -dict DHCPLeaseTimeSecs -int 600
+            sudo rm -f /var/db/dhcpd_leases
+          else
+            echo "::warning::Passwordless sudo is unavailable; skipping Tart DHCP cleanup"
+          fi
+
       - name: Write GitHub App private key
         if: matrix.needs-app-key
         run: |

--- a/.github/workflows/controller-integration-test.yaml
+++ b/.github/workflows/controller-integration-test.yaml
@@ -51,6 +51,14 @@ jobs:
       - name: Build dashboard (required for go:embed)
         run: cd dashboard && pnpm install --frozen-lockfile && pnpm run build
 
+      - name: Install Tart integration dependencies
+        if: matrix.name == 'Tart'
+        run: |
+          brew install cirruslabs/cli/tart cirruslabs/cli/sshpass gnupg
+          tart --version
+          sshpass -V
+          gpg --version
+
       - name: Write GitHub App private key
         if: matrix.needs-app-key
         run: |

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -25,6 +25,7 @@ export default function App() {
     utilPct,
     successCount,
     failureCount,
+    canceledCount,
     mood,
   } = useDashboardDerived()
 
@@ -178,9 +179,9 @@ export default function App() {
             </div>
             <div>
               <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>SUCCESS RATE</div>
-              <div style={{ fontSize: 16, fontWeight: 700, color: successCount + failureCount > 0 && failureCount / (successCount + failureCount) > 0.2 ? '#ff9500' : '#f0f0f0' }}>
-                {successCount + failureCount > 0
-                  ? `${Math.round(successCount / (successCount + failureCount) * 100)}%`
+              <div style={{ fontSize: 16, fontWeight: 700, color: successCount + failureCount + canceledCount > 0 && (failureCount + canceledCount) / (successCount + failureCount + canceledCount) > 0.2 ? '#ff9500' : '#f0f0f0' }}>
+                {successCount + failureCount + canceledCount > 0
+                  ? `${Math.round(successCount / (successCount + failureCount + canceledCount) * 100)}%`
                   : '—'}
               </div>
             </div>
@@ -229,8 +230,9 @@ export default function App() {
           { label: 'PREPARING', value: preparing,    color: '#aaa' },
           { label: 'IDLE',      value: idle,         color: '#888' },
           { label: 'BUSY',      value: busy,         color: '#f0f0f0' },
-          { label: 'COMPLETED', value: successCount, color: '#f0f0f0' },
+          { label: 'SUCCEEDED', value: successCount, color: '#f0f0f0' },
           { label: 'FAILED',    value: failureCount, color: failureCount > 0 ? '#ff3b30' : '#444' },
+          { label: 'CANCELED',  value: canceledCount, color: canceledCount > 0 ? '#ff9500' : '#444' },
         ].map((stat) => (
           <div key={stat.label} className="cell">
             <div className="label">{stat.label}</div>

--- a/dashboard/src/api/fetchers.ts
+++ b/dashboard/src/api/fetchers.ts
@@ -29,6 +29,7 @@ const JOB_RESULT_MAP: Record<string, JobRecord['result']> = {
   JOB_RESULT_RUNNING: 'running',
   JOB_RESULT_SUCCESS: 'success',
   JOB_RESULT_FAILURE: 'failure',
+  JOB_RESULT_CANCELED: 'canceled',
 }
 
 interface ServiceInfoResponse {

--- a/dashboard/src/components/JobRow.tsx
+++ b/dashboard/src/components/JobRow.tsx
@@ -11,6 +11,8 @@ export function JobRow({ job, now }: { job: JobRecord; now: Date }) {
     ? <span style={{ color: '#aaa', fontSize: 10, letterSpacing: '0.08em' }} className="pulse">RUN</span>
     : job.result === 'success'
     ? <span style={{ color: '#f0f0f0', fontSize: 10, letterSpacing: '0.08em' }}>OK</span>
+    : job.result === 'canceled'
+    ? <span style={{ color: '#ff9500', fontSize: 10, letterSpacing: '0.08em' }}>CXL</span>
     : <span style={{ color: '#ff3b30', fontSize: 10, letterSpacing: '0.08em' }}>FAIL</span>
 
   return (

--- a/dashboard/src/hooks/useDashboardDerived.ts
+++ b/dashboard/src/hooks/useDashboardDerived.ts
@@ -18,6 +18,7 @@ export function useDashboardDerived() {
   const completedJobs = recentJobs.filter(j => j.result !== 'running')
   const successCount = completedJobs.filter(j => j.result === 'success').length
   const failureCount = completedJobs.filter(j => j.result === 'failure').length
+  const canceledCount = completedJobs.filter(j => j.result === 'canceled').length
 
   const mood: PetMood =
     preparing > 0 ? 'alert' :
@@ -40,6 +41,7 @@ export function useDashboardDerived() {
     utilPct,
     successCount,
     failureCount,
+    canceledCount,
     mood,
   }
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -42,7 +42,7 @@ html, body, #root {
 
 .grid-stats {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   background: var(--border);
   gap: 1px;
   border: 1px solid var(--border);
@@ -82,7 +82,7 @@ html, body, #root {
     grid-template-columns: 1fr;
   }
   .grid-stats {
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(6, 1fr);
   }
 }
 
@@ -114,9 +114,6 @@ html, body, #root {
   }
   .grid-stats {
     grid-template-columns: repeat(3, 1fr);
-  }
-  .grid-stats > .cell:last-child {
-    grid-column: span 2;
   }
   .cell {
     padding: 16px;

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -1,6 +1,6 @@
 export type RunnerState = 'preparing' | 'idle' | 'busy' | 'unknown'
 export type Backend = 'tart' | 'docker' | 'unknown'
-export type JobResult = 'success' | 'failure' | 'running'
+export type JobResult = 'success' | 'failure' | 'canceled' | 'running'
 
 export interface Runner {
   name: string

--- a/features/jobstore/lifecycle.feature
+++ b/features/jobstore/lifecycle.feature
@@ -17,13 +17,13 @@ Feature: Job store lifecycle
 
   Scenario: recording a job completion
     Given job "job-1" was started on runner "runner-1" in set "set-a"
-    When I record job "job-1" completed with result "Succeeded"
-    Then job "job-1" should have result "Succeeded"
+    When I record job "job-1" completed with result "succeeded"
+    Then job "job-1" should have result "succeeded"
     And job "job-1" should have a completion time
 
   Scenario: completing an unknown job (orphan)
-    When I record job "orphan-job" completed with result "Failed"
-    Then job "orphan-job" should have result "Failed"
+    When I record job "orphan-job" completed with result "failed"
+    Then job "orphan-job" should have result "failed"
     And job "orphan-job" should have runner name ""
 
   Scenario: snapshot returns jobs in most-recent-first order
@@ -38,10 +38,11 @@ Feature: Job store lifecycle
     Given 250 jobs were started in set "set-a"
     Then the snapshot should contain 200 jobs
 
-  Scenario: recording a job with unexpected result
+  Scenario: rejecting a job completion with unexpected result
     Given job "job-1" was started on runner "runner-1" in set "set-a"
-    When I record job "job-1" completed with result "Cancelled"
-    Then job "job-1" should have result "Cancelled"
+    When I record job "job-1" completed with result "cancelled"
+    Then job "job-1" should have result "running"
+    And job "job-1" should not have a completion time
 
   Scenario: concurrent access is safe
     When 50 jobs are started and completed concurrently in set "set-a"

--- a/features/tart/vm_lifecycle.feature
+++ b/features/tart/vm_lifecycle.feature
@@ -1,0 +1,26 @@
+Feature: Tart VM lifecycle
+
+  The tart manager wraps the tart CLI for VM operations: pull, clone,
+  start, IP discovery, SSH exec, stop, and delete. These tests require
+  a real tart installation with nested virtualization enabled.
+
+  Scenario: pull, clone, start, exec, and cleanup a VM
+    Given a tart manager
+    When I pull the VM image
+    Then the VM image should exist locally
+    When I clone a VM with a random name
+    And I start the cloned VM
+    And I wait for the VM IP address
+    Then the VM IP should be a valid address
+    When I exec "echo hello" in the VM
+    Then the exec should succeed
+    When I stop and delete the VM
+    Then the VM should no longer exist
+
+  Scenario: list and cleanup orphaned VMs
+    Given a tart manager
+    When I clone a VM with a random name
+    And I start the cloned VM
+    Then listing local VMs should include the cloned VM
+    When I cleanup all VMs with the test prefix
+    Then listing local VMs should not include the cloned VM

--- a/features/tart/vm_lifecycle.feature
+++ b/features/tart/vm_lifecycle.feature
@@ -19,7 +19,8 @@ Feature: Tart VM lifecycle
 
   Scenario: list and cleanup orphaned VMs
     Given a tart manager
-    When I clone a VM with a random name
+    When I pull the VM image
+    And I clone a VM with a random name
     And I start the cloned VM
     Then listing local VMs should include the cloned VM
     When I cleanup all VMs with the test prefix

--- a/gen/controlplane/v1/controlplane.pb.go
+++ b/gen/controlplane/v1/controlplane.pb.go
@@ -131,6 +131,7 @@ const (
 	JobResult_JOB_RESULT_RUNNING     JobResult = 1
 	JobResult_JOB_RESULT_SUCCESS     JobResult = 2
 	JobResult_JOB_RESULT_FAILURE     JobResult = 3
+	JobResult_JOB_RESULT_CANCELED    JobResult = 4
 )
 
 // Enum value maps for JobResult.
@@ -140,12 +141,14 @@ var (
 		1: "JOB_RESULT_RUNNING",
 		2: "JOB_RESULT_SUCCESS",
 		3: "JOB_RESULT_FAILURE",
+		4: "JOB_RESULT_CANCELED",
 	}
 	JobResult_value = map[string]int32{
 		"JOB_RESULT_UNSPECIFIED": 0,
 		"JOB_RESULT_RUNNING":     1,
 		"JOB_RESULT_SUCCESS":     2,
 		"JOB_RESULT_FAILURE":     3,
+		"JOB_RESULT_CANCELED":    4,
 	}
 )
 
@@ -873,12 +876,13 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x18RUNNER_STATE_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16RUNNER_STATE_PREPARING\x10\x01\x12\x15\n" +
 	"\x11RUNNER_STATE_IDLE\x10\x02\x12\x15\n" +
-	"\x11RUNNER_STATE_BUSY\x10\x03*o\n" +
+	"\x11RUNNER_STATE_BUSY\x10\x03*\x88\x01\n" +
 	"\tJobResult\x12\x1a\n" +
 	"\x16JOB_RESULT_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12JOB_RESULT_RUNNING\x10\x01\x12\x16\n" +
 	"\x12JOB_RESULT_SUCCESS\x10\x02\x12\x16\n" +
-	"\x12JOB_RESULT_FAILURE\x10\x032\xa7\x03\n" +
+	"\x12JOB_RESULT_FAILURE\x10\x03\x12\x17\n" +
+	"\x13JOB_RESULT_CANCELED\x10\x042\xa7\x03\n" +
 	"\x13ControlPlaneService\x12a\n" +
 	"\x0eGetServiceInfo\x12&.controlplane.v1.GetServiceInfoRequest\x1a'.controlplane.v1.GetServiceInfoResponse\x12a\n" +
 	"\x0eListRunnerSets\x12&.controlplane.v1.ListRunnerSetsRequest\x1a'.controlplane.v1.ListRunnerSetsResponse\x12a\n" +

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -153,13 +152,15 @@ func toProtoBackend(b string) controlplanev1.Backend {
 }
 
 func toProtoJobResult(r string) controlplanev1.JobResult {
-	switch strings.ToLower(r) {
+	switch r {
 	case "running":
 		return controlplanev1.JobResult_JOB_RESULT_RUNNING
 	case "succeeded":
 		return controlplanev1.JobResult_JOB_RESULT_SUCCESS
 	case "failed":
 		return controlplanev1.JobResult_JOB_RESULT_FAILURE
+	case "canceled":
+		return controlplanev1.JobResult_JOB_RESULT_CANCELED
 	default:
 		return controlplanev1.JobResult_JOB_RESULT_UNSPECIFIED
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -152,12 +153,12 @@ func toProtoBackend(b string) controlplanev1.Backend {
 }
 
 func toProtoJobResult(r string) controlplanev1.JobResult {
-	switch r {
+	switch strings.ToLower(r) {
 	case "running":
 		return controlplanev1.JobResult_JOB_RESULT_RUNNING
-	case "Succeeded":
+	case "succeeded":
 		return controlplanev1.JobResult_JOB_RESULT_SUCCESS
-	case "Failed":
+	case "failed":
 		return controlplanev1.JobResult_JOB_RESULT_FAILURE
 	default:
 		return controlplanev1.JobResult_JOB_RESULT_UNSPECIFIED

--- a/internal/management/jobs.go
+++ b/internal/management/jobs.go
@@ -32,7 +32,10 @@ func NewJobStore(db *sql.DB) *JobStore {
 }
 
 // knownJobResults is the set of valid result strings from the GitHub Actions API.
+// GitHub sends these in lowercase ("succeeded", "failed").
 var knownJobResults = map[string]struct{}{
+	"succeeded": {},
+	"failed":    {},
 	"Succeeded": {},
 	"Failed":    {},
 }

--- a/internal/management/jobs.go
+++ b/internal/management/jobs.go
@@ -31,13 +31,11 @@ func NewJobStore(db *sql.DB) *JobStore {
 	}
 }
 
-// knownJobResults is the set of valid result strings from the GitHub Actions API.
-// GitHub sends these in lowercase ("succeeded", "failed").
+// knownJobResults is the set of valid result strings from the GitHub Scale Set API.
 var knownJobResults = map[string]struct{}{
 	"succeeded": {},
 	"failed":    {},
-	"Succeeded": {},
-	"Failed":    {},
+	"canceled":  {},
 }
 
 // RecordJobStarted inserts a new job with result "running".
@@ -59,7 +57,8 @@ func (s *JobStore) RecordJobStarted(setName, jobID, runnerName string) {
 // If the job does not exist, inserts a completed-only record.
 func (s *JobStore) RecordJobCompleted(jobID, result string) {
 	if _, ok := knownJobResults[result]; !ok {
-		slog.Warn("unexpected job result from scale-set API, recording as-is", "job_id", jobID, "result", result)
+		slog.Error("unexpected job result from scale-set API, refusing to record invalid state", "job_id", jobID, "result", result)
+		return
 	}
 
 	ctx := context.Background()

--- a/internal/management/service_test.go
+++ b/internal/management/service_test.go
@@ -66,7 +66,7 @@ func TestOpenJobsDB_JobStoreOperations(t *testing.T) {
 	store := NewJobStore(db)
 
 	store.RecordJobStarted("set-1", "job-1", "runner-1")
-	store.RecordJobCompleted("job-1", "Succeeded")
+	store.RecordJobCompleted("job-1", "succeeded")
 
 	jobs := store.Snapshot()
 	if len(jobs) != 1 {
@@ -75,8 +75,8 @@ func TestOpenJobsDB_JobStoreOperations(t *testing.T) {
 	if jobs[0].ID != "job-1" {
 		t.Errorf("job ID = %q, want %q", jobs[0].ID, "job-1")
 	}
-	if jobs[0].Result != "Succeeded" {
-		t.Errorf("job result = %q, want %q", jobs[0].Result, "Succeeded")
+	if jobs[0].Result != "succeeded" {
+		t.Errorf("job result = %q, want %q", jobs[0].Result, "succeeded")
 	}
 	if jobs[0].CompletedAt == nil {
 		t.Error("expected CompletedAt to be set")

--- a/internal/tart/manager.go
+++ b/internal/tart/manager.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 )
 
 var tracer = otel.Tracer("github.com/boring-design/elastic-fruit-runner/internal/tart")
+
+const ipAddressWaitSeconds = 180
 
 // Manager wraps the tart CLI for VM lifecycle operations.
 // All operations call `tart` which must be installed on the host.
@@ -121,7 +124,7 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	return nil
 }
 
-// IPAddress waits up to 60 s for the VM to get a DHCP address and returns it.
+// IPAddress waits for the VM to get a DHCP address and returns it.
 func (m *Manager) IPAddress(ctx context.Context, name string) (string, error) {
 	ctx, span := tracer.Start(ctx, "tart.ip_address",
 		trace.WithAttributes(attribute.String("vm.name", name)),
@@ -129,10 +132,10 @@ func (m *Manager) IPAddress(ctx context.Context, name string) (string, error) {
 	defer span.End()
 
 	slog.Info("waiting for VM IP", "name", name)
-	cmd := exec.CommandContext(ctx, binpath.Lookup("tart"), "ip", name, "--wait", "60")
-	out, err := cmd.Output()
+	cmd := exec.CommandContext(ctx, binpath.Lookup("tart"), "ip", name, "--wait", strconv.Itoa(ipAddressWaitSeconds))
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		err = fmt.Errorf("tart ip %s: %w", name, err)
+		err = fmt.Errorf("tart ip %s: %w\n%s", name, err, out)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return "", err

--- a/internal/tart/manager.go
+++ b/internal/tart/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -113,6 +114,8 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 
 	slog.Info("starting VM", "name", name)
 	cmd := exec.CommandContext(ctx, binpath.Lookup("tart"), "run", name, "--no-graphics")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		err = fmt.Errorf("start VM %s: %w", name, err)
 		span.RecordError(err)

--- a/internal/tart/manager.go
+++ b/internal/tart/manager.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 
@@ -21,7 +20,7 @@ import (
 
 var tracer = otel.Tracer("github.com/boring-design/elastic-fruit-runner/internal/tart")
 
-const ipAddressWaitSeconds = 180
+const ipAddressWaitSeconds = "180"
 
 // Manager wraps the tart CLI for VM lifecycle operations.
 // All operations call `tart` which must be installed on the host.
@@ -135,7 +134,7 @@ func (m *Manager) IPAddress(ctx context.Context, name string) (string, error) {
 	defer span.End()
 
 	slog.Info("waiting for VM IP", "name", name)
-	cmd := exec.CommandContext(ctx, binpath.Lookup("tart"), "ip", name, "--wait", strconv.Itoa(ipAddressWaitSeconds))
+	cmd := exec.CommandContext(ctx, binpath.Lookup("tart"), "ip", name, "--wait", ipAddressWaitSeconds)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		err = fmt.Errorf("tart ip %s: %w\n%s", name, err, out)

--- a/proto/controlplane/v1/controlplane.proto
+++ b/proto/controlplane/v1/controlplane.proto
@@ -108,6 +108,7 @@ enum JobResult {
   JOB_RESULT_RUNNING = 1;
   JOB_RESULT_SUCCESS = 2;
   JOB_RESULT_FAILURE = 3;
+  JOB_RESULT_CANCELED = 4;
 }
 
 message JobRecord {

--- a/test/integration/steps_test.go
+++ b/test/integration/steps_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/boring-design/elastic-fruit-runner/internal/binpath"
 	"github.com/boring-design/elastic-fruit-runner/internal/management"
 	"github.com/boring-design/elastic-fruit-runner/internal/management/migrations"
+	"github.com/boring-design/elastic-fruit-runner/internal/tart"
 	"github.com/boring-design/elastic-fruit-runner/internal/vitals"
 )
 
@@ -67,6 +68,12 @@ type scenarioState struct {
 	workflowResult *github.WorkflowRun
 	runnerSetsResp *controlplanev1.ListRunnerSetsResponse
 	jobRecordsResp *controlplanev1.ListJobRecordsResponse
+
+	// tart steps
+	tartMgr    *tart.Manager
+	tartVMName string
+	tartVMIP   string
+	tartPrefix string
 }
 
 func initializeScenario(sc *godog.ScenarioContext) {
@@ -648,6 +655,128 @@ func initializeScenario(sc *godog.ScenarioContext) {
 			state.mgmtService.Wait()
 			state.mgmtService.Close()
 		}
+	})
+
+	// ---- Tart VM steps ----
+	sc.Step(`^a tart manager$`, func(ctx context.Context) (context.Context, error) {
+		if binpath.Lookup("tart") == "tart" {
+			return ctx, godog.ErrPending
+		}
+		state.tartMgr = tart.NewManager()
+		state.tartPrefix = "efr-tart-test"
+		return ctx, nil
+	})
+
+	sc.Step(`^I pull the VM image$`, func() error {
+		image := envOrDefault("EFR_TEST_TART_IMAGE", "ghcr.io/cirruslabs/macos-tahoe-base:latest")
+		return state.tartMgr.Pull(context.Background(), image)
+	})
+
+	sc.Step(`^the VM image should exist locally$`, func() error {
+		image := envOrDefault("EFR_TEST_TART_IMAGE", "ghcr.io/cirruslabs/macos-tahoe-base:latest")
+		exists, err := state.tartMgr.ImageExists(context.Background(), image)
+		if err != nil {
+			return fmt.Errorf("check image exists: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("image %q not found locally after pull", image)
+		}
+		return nil
+	})
+
+	sc.Step(`^I clone a VM with a random name$`, func() error {
+		image := envOrDefault("EFR_TEST_TART_IMAGE", "ghcr.io/cirruslabs/macos-tahoe-base:latest")
+		state.tartVMName = state.tartPrefix + "-" + randomSuffix()
+		return state.tartMgr.Clone(context.Background(), image, state.tartVMName)
+	})
+
+	sc.Step(`^I start the cloned VM$`, func() error {
+		return state.tartMgr.Start(context.Background(), state.tartVMName)
+	})
+
+	sc.Step(`^I wait for the VM IP address$`, func() error {
+		ip, err := state.tartMgr.IPAddress(context.Background(), state.tartVMName)
+		if err != nil {
+			return err
+		}
+		state.tartVMIP = ip
+		return nil
+	})
+
+	sc.Step(`^the VM IP should be a valid address$`, func() error {
+		if net.ParseIP(state.tartVMIP) == nil {
+			return fmt.Errorf("invalid IP address: %q", state.tartVMIP)
+		}
+		return nil
+	})
+
+	sc.Step(`^I exec "([^"]*)" in the VM$`, func(cmd string) error {
+		return state.tartMgr.Exec(context.Background(), state.tartVMName, "bash", "-c", cmd)
+	})
+
+	sc.Step(`^the exec should succeed$`, func() error {
+		// The step above already returns error on failure
+		return nil
+	})
+
+	sc.Step(`^I stop and delete the VM$`, func() error {
+		if err := state.tartMgr.Stop(context.Background(), state.tartVMName); err != nil {
+			return fmt.Errorf("stop VM: %w", err)
+		}
+		return state.tartMgr.Delete(context.Background(), state.tartVMName)
+	})
+
+	sc.Step(`^the VM should no longer exist$`, func() error {
+		vms, err := state.tartMgr.List(context.Background())
+		if err != nil {
+			return err
+		}
+		for _, name := range vms {
+			if name == state.tartVMName {
+				return fmt.Errorf("VM %q still exists after delete", state.tartVMName)
+			}
+		}
+		return nil
+	})
+
+	sc.Step(`^listing local VMs should include the cloned VM$`, func() error {
+		vms, err := state.tartMgr.List(context.Background())
+		if err != nil {
+			return err
+		}
+		for _, name := range vms {
+			if name == state.tartVMName {
+				return nil
+			}
+		}
+		return fmt.Errorf("VM %q not found in list", state.tartVMName)
+	})
+
+	sc.Step(`^I cleanup all VMs with the test prefix$`, func() error {
+		vms, err := state.tartMgr.List(context.Background())
+		if err != nil {
+			return err
+		}
+		for _, name := range vms {
+			if strings.HasPrefix(name, state.tartPrefix+"-") {
+				_ = state.tartMgr.Stop(context.Background(), name)
+				_ = state.tartMgr.Delete(context.Background(), name)
+			}
+		}
+		return nil
+	})
+
+	sc.Step(`^listing local VMs should not include the cloned VM$`, func() error {
+		vms, err := state.tartMgr.List(context.Background())
+		if err != nil {
+			return err
+		}
+		for _, name := range vms {
+			if name == state.tartVMName {
+				return fmt.Errorf("VM %q still exists after cleanup", state.tartVMName)
+			}
+		}
+		return nil
 	})
 }
 

--- a/test/integration/steps_test.go
+++ b/test/integration/steps_test.go
@@ -682,6 +682,13 @@ func initializeScenario(sc *godog.ScenarioContext) {
 		if err != nil {
 			return err
 		}
+		if imageRefUsesDigest(image) {
+			name := state.tartPrefix + "-image-check-" + randomSuffix()
+			if err := state.tartMgr.Clone(context.Background(), image, name); err != nil {
+				return fmt.Errorf("verify digest-pinned image %q by cloning %q: %w", image, name, err)
+			}
+			return cleanupTartVM(context.Background(), state.tartMgr, name)
+		}
 		exists, err := state.tartMgr.ImageExists(context.Background(), image)
 		if err != nil {
 			return fmt.Errorf("check image exists: %w", err)
@@ -797,6 +804,10 @@ func tartTestImage() (string, error) {
 		return "", fmt.Errorf("EFR_TEST_TART_IMAGE must be pinned to a fixed tag or digest, got %q", image)
 	}
 	return image, nil
+}
+
+func imageRefUsesDigest(image string) bool {
+	return strings.Contains(image, "@sha256:")
 }
 
 func cleanupTartVMs(ctx context.Context, state *scenarioState) error {

--- a/test/integration/steps_test.go
+++ b/test/integration/steps_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -83,6 +84,7 @@ func initializeScenario(sc *godog.ScenarioContext) {
 	}
 
 	sc.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
+		cleanupErr := cleanupTartVMs(ctx, state)
 		// restore env vars
 		for key, old := range state.oldEnvVars {
 			if old == "\x00" {
@@ -99,7 +101,7 @@ func initializeScenario(sc *godog.ScenarioContext) {
 		if state.db != nil {
 			state.db.Close()
 		}
-		return ctx, nil
+		return ctx, cleanupErr
 	})
 
 	// ---- Config steps ----
@@ -439,7 +441,7 @@ func initializeScenario(sc *godog.ScenarioContext) {
 				defer wg.Done()
 				id := fmt.Sprintf("job-%d", idx)
 				state.jobStore.RecordJobStarted(set, id, fmt.Sprintf("runner-%d", idx))
-				state.jobStore.RecordJobCompleted(id, "Succeeded")
+				state.jobStore.RecordJobCompleted(id, "succeeded")
 			}(i)
 		}
 		wg.Wait()
@@ -660,7 +662,7 @@ func initializeScenario(sc *godog.ScenarioContext) {
 	// ---- Tart VM steps ----
 	sc.Step(`^a tart manager$`, func(ctx context.Context) (context.Context, error) {
 		if binpath.Lookup("tart") == "tart" {
-			return ctx, godog.ErrPending
+			return ctx, fmt.Errorf("tart binary not found in PATH; install via `brew install cirruslabs/cli/tart`")
 		}
 		state.tartMgr = tart.NewManager()
 		state.tartPrefix = "efr-tart-test"
@@ -668,12 +670,18 @@ func initializeScenario(sc *godog.ScenarioContext) {
 	})
 
 	sc.Step(`^I pull the VM image$`, func() error {
-		image := envOrDefault("EFR_TEST_TART_IMAGE", "ghcr.io/cirruslabs/macos-tahoe-base:latest")
+		image, err := tartTestImage()
+		if err != nil {
+			return err
+		}
 		return state.tartMgr.Pull(context.Background(), image)
 	})
 
 	sc.Step(`^the VM image should exist locally$`, func() error {
-		image := envOrDefault("EFR_TEST_TART_IMAGE", "ghcr.io/cirruslabs/macos-tahoe-base:latest")
+		image, err := tartTestImage()
+		if err != nil {
+			return err
+		}
 		exists, err := state.tartMgr.ImageExists(context.Background(), image)
 		if err != nil {
 			return fmt.Errorf("check image exists: %w", err)
@@ -685,7 +693,10 @@ func initializeScenario(sc *godog.ScenarioContext) {
 	})
 
 	sc.Step(`^I clone a VM with a random name$`, func() error {
-		image := envOrDefault("EFR_TEST_TART_IMAGE", "ghcr.io/cirruslabs/macos-tahoe-base:latest")
+		image, err := tartTestImage()
+		if err != nil {
+			return err
+		}
 		state.tartVMName = state.tartPrefix + "-" + randomSuffix()
 		return state.tartMgr.Clone(context.Background(), image, state.tartVMName)
 	})
@@ -720,10 +731,7 @@ func initializeScenario(sc *godog.ScenarioContext) {
 	})
 
 	sc.Step(`^I stop and delete the VM$`, func() error {
-		if err := state.tartMgr.Stop(context.Background(), state.tartVMName); err != nil {
-			return fmt.Errorf("stop VM: %w", err)
-		}
-		return state.tartMgr.Delete(context.Background(), state.tartVMName)
+		return cleanupTartVM(context.Background(), state.tartMgr, state.tartVMName)
 	})
 
 	sc.Step(`^the VM should no longer exist$`, func() error {
@@ -759,8 +767,9 @@ func initializeScenario(sc *godog.ScenarioContext) {
 		}
 		for _, name := range vms {
 			if strings.HasPrefix(name, state.tartPrefix+"-") {
-				_ = state.tartMgr.Stop(context.Background(), name)
-				_ = state.tartMgr.Delete(context.Background(), name)
+				if err := cleanupTartVM(context.Background(), state.tartMgr, name); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -778,6 +787,48 @@ func initializeScenario(sc *godog.ScenarioContext) {
 		}
 		return nil
 	})
+}
+
+const defaultTartTestImage = "ghcr.io/cirruslabs/macos-tahoe-base@sha256:6abd551a46da4e595b6a9f678535a8f1bbd61bdc275a363265cd39281d3abdef"
+
+func tartTestImage() (string, error) {
+	image := envOrDefault("EFR_TEST_TART_IMAGE", defaultTartTestImage)
+	if strings.Contains(image, ":latest") {
+		return "", fmt.Errorf("EFR_TEST_TART_IMAGE must be pinned to a fixed tag or digest, got %q", image)
+	}
+	return image, nil
+}
+
+func cleanupTartVMs(ctx context.Context, state *scenarioState) error {
+	if state.tartMgr == nil || state.tartPrefix == "" {
+		return nil
+	}
+	vms, err := state.tartMgr.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list tart VMs during cleanup: %w", err)
+	}
+	var cleanupErr error
+	for _, name := range vms {
+		if strings.HasPrefix(name, state.tartPrefix+"-") {
+			cleanupErr = errors.Join(cleanupErr, cleanupTartVM(ctx, state.tartMgr, name))
+		}
+	}
+	return cleanupErr
+}
+
+func cleanupTartVM(ctx context.Context, mgr *tart.Manager, name string) error {
+	stopErr := mgr.Stop(ctx, name)
+	deleteErr := mgr.Delete(ctx, name)
+	if deleteErr == nil {
+		return nil
+	}
+	if stopErr != nil {
+		return errors.Join(
+			fmt.Errorf("stop tart VM %q: %w", name, stopErr),
+			fmt.Errorf("delete tart VM %q: %w", name, deleteErr),
+		)
+	}
+	return fmt.Errorf("delete tart VM %q: %w", name, deleteErr)
 }
 
 // buildMgmtConfig creates a management service config from env vars with the given auth.


### PR DESCRIPTION
## Summary
- Add BDD integration tests for tart VM lifecycle (pull, clone, start, IP, exec, stop, delete, cleanup)
- Uses `ghcr.io/cirruslabs/macos-tahoe-base:latest` as smaller test image (no Xcode)
- Tart steps auto-skip when `tart` binary is not available
- CI matrix adds "Tart" job on self-hosted macOS arm64 runner with nested virtualization

## Test plan
- [ ] Verify tart tests pass on self-hosted macOS arm64 runner
- [ ] Verify non-tart integration tests still pass
- [ ] Verify tart tests skip gracefully on runners without tart installed