### PR TITLE
[codex] Use Go build info metadata

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -52,7 +52,7 @@ const { daemonStatus, runnerSets, recentJobs } = await fetch('/api/status').then
 The data shape expected by the dashboard:
 
 ```ts
-DaemonStatus   // version, commitSha, startedAt, githubConnected, idleTimeout
+DaemonStatus   // buildInfo, startedAt, githubConnected, idleTimeout
 RunnerSet[]    // name, backend, image, labels, maxRunners, scope, runners[]
 JobRecord[]    // id, runnerName, runnerSetName, result, startedAt, completedAt
 ```

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -45,6 +45,11 @@ export default function App() {
     )
   }
 
+  const version = daemonStatus.buildInfo?.main?.version && daemonStatus.buildInfo.main.version !== '(devel)'
+    ? daemonStatus.buildInfo.main.version
+    : 'dev'
+  const vcsRevision = daemonStatus.buildInfo?.settings.find(setting => setting.key === 'vcs.revision')?.value ?? 'unknown'
+
   return (
     <div className="app-container">
 
@@ -55,7 +60,7 @@ export default function App() {
             ELASTIC-FRUIT-RUNNER
           </span>
           <span style={{ color: '#555', fontSize: 11, letterSpacing: '0.08em' }}>
-            v{daemonStatus.version} · {daemonStatus.commitSha}
+            v{version} · {vcsRevision}
           </span>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>

--- a/dashboard/src/api/fetchers.ts
+++ b/dashboard/src/api/fetchers.ts
@@ -1,4 +1,4 @@
-import type { DaemonStatus, RunnerSet, JobRecord, Runner, MachineVitals } from '../types'
+import type { DaemonStatus, RunnerSet, JobRecord, Runner, MachineVitals, BuildInfo, Module } from '../types'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
@@ -32,10 +32,27 @@ const JOB_RESULT_MAP: Record<string, JobRecord['result']> = {
 }
 
 interface ServiceInfoResponse {
-  version: string
-  commitSha: string
+  buildInfo?: BuildInfoResponse
   startedAt: string
   idleTimeoutSeconds: number
+}
+
+interface BuildInfoResponse {
+  goVersion?: string
+  path?: string
+  main?: ModuleResponse
+  deps?: ModuleResponse[]
+  settings?: Array<{
+    key?: string
+    value?: string
+  }>
+}
+
+interface ModuleResponse {
+  path?: string
+  version?: string
+  sum?: string
+  replace?: ModuleResponse
 }
 
 interface RunnerSetsResponse {
@@ -83,11 +100,32 @@ export async function fetchDaemonStatus(): Promise<DaemonStatus> {
     ? cachedRunnerSets.every(rs => rs.connected)
     : null
   return {
-    version: data.version,
-    commitSha: data.commitSha,
+    buildInfo: data.buildInfo ? toBuildInfo(data.buildInfo) : null,
     startedAt: new Date(data.startedAt),
     githubConnected,
     idleTimeout: data.idleTimeoutSeconds,
+  }
+}
+
+function toBuildInfo(data: BuildInfoResponse): BuildInfo {
+  return {
+    goVersion: data.goVersion ?? '',
+    path: data.path ?? '',
+    main: data.main ? toModule(data.main) : null,
+    deps: (data.deps ?? []).map(toModule),
+    settings: (data.settings ?? []).map(setting => ({
+      key: setting.key ?? '',
+      value: setting.value ?? '',
+    })),
+  }
+}
+
+function toModule(data: ModuleResponse): Module {
+  return {
+    path: data.path ?? '',
+    version: data.version ?? '',
+    sum: data.sum ?? '',
+    replace: data.replace ? toModule(data.replace) : null,
   }
 }
 

--- a/dashboard/src/mock.ts
+++ b/dashboard/src/mock.ts
@@ -4,8 +4,20 @@ const now = new Date()
 const ago = (s: number) => new Date(now.getTime() - s * 1000)
 
 export const daemonStatus: DaemonStatus = {
-  version: '0.2.1',
-  commitSha: 'a3f2c1d',
+  buildInfo: {
+    goVersion: 'go1.25.7',
+    path: 'github.com/boring-design/elastic-fruit-runner/cmd/elastic-fruit-runner',
+    main: {
+      path: 'github.com/boring-design/elastic-fruit-runner',
+      version: 'v0.2.1',
+      sum: '',
+      replace: null,
+    },
+    deps: [],
+    settings: [
+      { key: 'vcs.revision', value: 'a3f2c1d' },
+    ],
+  },
   startedAt: ago(9252),
   githubConnected: true,
   idleTimeout: 900,

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -29,12 +29,31 @@ export interface JobRecord {
 }
 
 export interface DaemonStatus {
-  version: string
-  commitSha: string
+  buildInfo: BuildInfo | null
   startedAt: Date
   // null while runner set data has not been fetched yet (loading state)
   githubConnected: boolean | null
   idleTimeout: number
+}
+
+export interface BuildInfo {
+  goVersion: string
+  path: string
+  main: Module | null
+  deps: Module[]
+  settings: BuildSetting[]
+}
+
+export interface Module {
+  path: string
+  version: string
+  sum: string
+  replace: Module | null
+}
+
+export interface BuildSetting {
+  key: string
+  value: string
 }
 
 export interface MachineVitals {

--- a/gen/controlplane/v1/controlplane.pb.go
+++ b/gen/controlplane/v1/controlplane.pb.go
@@ -214,14 +214,12 @@ func (*GetServiceInfoRequest) Descriptor() ([]byte, []int) {
 
 type GetServiceInfoResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Semantic version set at build time via -ldflags.
-	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
-	// Git commit hash set at build time via -ldflags.
-	CommitSha string `protobuf:"bytes,2,opt,name=commit_sha,json=commitSha,proto3" json:"commit_sha,omitempty"`
+	// Go build metadata embedded in the daemon binary.
+	BuildInfo *BuildInfo `protobuf:"bytes,1,opt,name=build_info,json=buildInfo,proto3" json:"build_info,omitempty"`
 	// When the daemon process started.
-	StartedAt *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	StartedAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
 	// Configured idle runner timeout in seconds.
-	IdleTimeoutSeconds int32 `protobuf:"varint,4,opt,name=idle_timeout_seconds,json=idleTimeoutSeconds,proto3" json:"idle_timeout_seconds,omitempty"`
+	IdleTimeoutSeconds int32 `protobuf:"varint,3,opt,name=idle_timeout_seconds,json=idleTimeoutSeconds,proto3" json:"idle_timeout_seconds,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -256,18 +254,11 @@ func (*GetServiceInfoResponse) Descriptor() ([]byte, []int) {
 	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *GetServiceInfoResponse) GetVersion() string {
+func (x *GetServiceInfoResponse) GetBuildInfo() *BuildInfo {
 	if x != nil {
-		return x.Version
+		return x.BuildInfo
 	}
-	return ""
-}
-
-func (x *GetServiceInfoResponse) GetCommitSha() string {
-	if x != nil {
-		return x.CommitSha
-	}
-	return ""
+	return nil
 }
 
 func (x *GetServiceInfoResponse) GetStartedAt() *timestamppb.Timestamp {
@@ -284,6 +275,207 @@ func (x *GetServiceInfoResponse) GetIdleTimeoutSeconds() int32 {
 	return 0
 }
 
+type BuildInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Go toolchain version used to build the binary.
+	GoVersion string `protobuf:"bytes,1,opt,name=go_version,json=goVersion,proto3" json:"go_version,omitempty"`
+	// Main package path.
+	Path string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	// Main module.
+	Main *Module `protobuf:"bytes,3,opt,name=main,proto3" json:"main,omitempty"`
+	// Dependency modules.
+	Deps []*Module `protobuf:"bytes,4,rep,name=deps,proto3" json:"deps,omitempty"`
+	// Build settings such as VCS metadata.
+	Settings      []*BuildSetting `protobuf:"bytes,5,rep,name=settings,proto3" json:"settings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BuildInfo) Reset() {
+	*x = BuildInfo{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BuildInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BuildInfo) ProtoMessage() {}
+
+func (x *BuildInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BuildInfo.ProtoReflect.Descriptor instead.
+func (*BuildInfo) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *BuildInfo) GetGoVersion() string {
+	if x != nil {
+		return x.GoVersion
+	}
+	return ""
+}
+
+func (x *BuildInfo) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *BuildInfo) GetMain() *Module {
+	if x != nil {
+		return x.Main
+	}
+	return nil
+}
+
+func (x *BuildInfo) GetDeps() []*Module {
+	if x != nil {
+		return x.Deps
+	}
+	return nil
+}
+
+func (x *BuildInfo) GetSettings() []*BuildSetting {
+	if x != nil {
+		return x.Settings
+	}
+	return nil
+}
+
+type Module struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	Sum           string                 `protobuf:"bytes,3,opt,name=sum,proto3" json:"sum,omitempty"`
+	Replace       *Module                `protobuf:"bytes,4,opt,name=replace,proto3" json:"replace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Module) Reset() {
+	*x = Module{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Module) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Module) ProtoMessage() {}
+
+func (x *Module) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Module.ProtoReflect.Descriptor instead.
+func (*Module) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *Module) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *Module) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *Module) GetSum() string {
+	if x != nil {
+		return x.Sum
+	}
+	return ""
+}
+
+func (x *Module) GetReplace() *Module {
+	if x != nil {
+		return x.Replace
+	}
+	return nil
+}
+
+type BuildSetting struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BuildSetting) Reset() {
+	*x = BuildSetting{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BuildSetting) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BuildSetting) ProtoMessage() {}
+
+func (x *BuildSetting) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BuildSetting.ProtoReflect.Descriptor instead.
+func (*BuildSetting) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *BuildSetting) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *BuildSetting) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
 type ListRunnerSetsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -292,7 +484,7 @@ type ListRunnerSetsRequest struct {
 
 func (x *ListRunnerSetsRequest) Reset() {
 	*x = ListRunnerSetsRequest{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[2]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -304,7 +496,7 @@ func (x *ListRunnerSetsRequest) String() string {
 func (*ListRunnerSetsRequest) ProtoMessage() {}
 
 func (x *ListRunnerSetsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[2]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -317,7 +509,7 @@ func (x *ListRunnerSetsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunnerSetsRequest.ProtoReflect.Descriptor instead.
 func (*ListRunnerSetsRequest) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{2}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{5}
 }
 
 type ListRunnerSetsResponse struct {
@@ -329,7 +521,7 @@ type ListRunnerSetsResponse struct {
 
 func (x *ListRunnerSetsResponse) Reset() {
 	*x = ListRunnerSetsResponse{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[3]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -341,7 +533,7 @@ func (x *ListRunnerSetsResponse) String() string {
 func (*ListRunnerSetsResponse) ProtoMessage() {}
 
 func (x *ListRunnerSetsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[3]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -354,7 +546,7 @@ func (x *ListRunnerSetsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRunnerSetsResponse.ProtoReflect.Descriptor instead.
 func (*ListRunnerSetsResponse) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{3}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListRunnerSetsResponse) GetRunnerSets() []*RunnerSet {
@@ -389,7 +581,7 @@ type RunnerSet struct {
 
 func (x *RunnerSet) Reset() {
 	*x = RunnerSet{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[4]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -401,7 +593,7 @@ func (x *RunnerSet) String() string {
 func (*RunnerSet) ProtoMessage() {}
 
 func (x *RunnerSet) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[4]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -414,7 +606,7 @@ func (x *RunnerSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunnerSet.ProtoReflect.Descriptor instead.
 func (*RunnerSet) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{4}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RunnerSet) GetName() string {
@@ -487,7 +679,7 @@ type Runner struct {
 
 func (x *Runner) Reset() {
 	*x = Runner{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[5]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -499,7 +691,7 @@ func (x *Runner) String() string {
 func (*Runner) ProtoMessage() {}
 
 func (x *Runner) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[5]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -512,7 +704,7 @@ func (x *Runner) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Runner.ProtoReflect.Descriptor instead.
 func (*Runner) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{5}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Runner) GetName() string {
@@ -544,7 +736,7 @@ type ListJobRecordsRequest struct {
 
 func (x *ListJobRecordsRequest) Reset() {
 	*x = ListJobRecordsRequest{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[6]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -556,7 +748,7 @@ func (x *ListJobRecordsRequest) String() string {
 func (*ListJobRecordsRequest) ProtoMessage() {}
 
 func (x *ListJobRecordsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[6]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -569,7 +761,7 @@ func (x *ListJobRecordsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListJobRecordsRequest.ProtoReflect.Descriptor instead.
 func (*ListJobRecordsRequest) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{6}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{9}
 }
 
 type ListJobRecordsResponse struct {
@@ -581,7 +773,7 @@ type ListJobRecordsResponse struct {
 
 func (x *ListJobRecordsResponse) Reset() {
 	*x = ListJobRecordsResponse{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[7]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -593,7 +785,7 @@ func (x *ListJobRecordsResponse) String() string {
 func (*ListJobRecordsResponse) ProtoMessage() {}
 
 func (x *ListJobRecordsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[7]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -606,7 +798,7 @@ func (x *ListJobRecordsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListJobRecordsResponse.ProtoReflect.Descriptor instead.
 func (*ListJobRecordsResponse) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{7}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListJobRecordsResponse) GetJobRecords() []*JobRecord {
@@ -636,7 +828,7 @@ type JobRecord struct {
 
 func (x *JobRecord) Reset() {
 	*x = JobRecord{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[8]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -648,7 +840,7 @@ func (x *JobRecord) String() string {
 func (*JobRecord) ProtoMessage() {}
 
 func (x *JobRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[8]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -661,7 +853,7 @@ func (x *JobRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JobRecord.ProtoReflect.Descriptor instead.
 func (*JobRecord) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{8}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *JobRecord) GetId() string {
@@ -714,7 +906,7 @@ type GetMachineVitalsRequest struct {
 
 func (x *GetMachineVitalsRequest) Reset() {
 	*x = GetMachineVitalsRequest{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[9]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -726,7 +918,7 @@ func (x *GetMachineVitalsRequest) String() string {
 func (*GetMachineVitalsRequest) ProtoMessage() {}
 
 func (x *GetMachineVitalsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[9]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -739,7 +931,7 @@ func (x *GetMachineVitalsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMachineVitalsRequest.ProtoReflect.Descriptor instead.
 func (*GetMachineVitalsRequest) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{9}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{12}
 }
 
 type GetMachineVitalsResponse struct {
@@ -758,7 +950,7 @@ type GetMachineVitalsResponse struct {
 
 func (x *GetMachineVitalsResponse) Reset() {
 	*x = GetMachineVitalsResponse{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[10]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -770,7 +962,7 @@ func (x *GetMachineVitalsResponse) String() string {
 func (*GetMachineVitalsResponse) ProtoMessage() {}
 
 func (x *GetMachineVitalsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[10]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -783,7 +975,7 @@ func (x *GetMachineVitalsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMachineVitalsResponse.ProtoReflect.Descriptor instead.
 func (*GetMachineVitalsResponse) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{10}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetMachineVitalsResponse) GetCpuUsagePercent() float32 {
@@ -819,14 +1011,28 @@ var File_controlplane_v1_controlplane_proto protoreflect.FileDescriptor
 const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\n" +
 	"\"controlplane/v1/controlplane.proto\x12\x0fcontrolplane.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x17\n" +
-	"\x15GetServiceInfoRequest\"\xbe\x01\n" +
-	"\x16GetServiceInfoResponse\x12\x18\n" +
-	"\aversion\x18\x01 \x01(\tR\aversion\x12\x1d\n" +
+	"\x15GetServiceInfoRequest\"\xc0\x01\n" +
+	"\x16GetServiceInfoResponse\x129\n" +
 	"\n" +
-	"commit_sha\x18\x02 \x01(\tR\tcommitSha\x129\n" +
+	"build_info\x18\x01 \x01(\v2\x1a.controlplane.v1.BuildInfoR\tbuildInfo\x129\n" +
 	"\n" +
-	"started_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x120\n" +
-	"\x14idle_timeout_seconds\x18\x04 \x01(\x05R\x12idleTimeoutSeconds\"\x17\n" +
+	"started_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x120\n" +
+	"\x14idle_timeout_seconds\x18\x03 \x01(\x05R\x12idleTimeoutSeconds\"\xd3\x01\n" +
+	"\tBuildInfo\x12\x1d\n" +
+	"\n" +
+	"go_version\x18\x01 \x01(\tR\tgoVersion\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\x12+\n" +
+	"\x04main\x18\x03 \x01(\v2\x17.controlplane.v1.ModuleR\x04main\x12+\n" +
+	"\x04deps\x18\x04 \x03(\v2\x17.controlplane.v1.ModuleR\x04deps\x129\n" +
+	"\bsettings\x18\x05 \x03(\v2\x1d.controlplane.v1.BuildSettingR\bsettings\"{\n" +
+	"\x06Module\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\x12\x10\n" +
+	"\x03sum\x18\x03 \x01(\tR\x03sum\x121\n" +
+	"\areplace\x18\x04 \x01(\v2\x17.controlplane.v1.ModuleR\areplace\"6\n" +
+	"\fBuildSetting\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"\x17\n" +
 	"\x15ListRunnerSetsRequest\"U\n" +
 	"\x16ListRunnerSetsResponse\x12;\n" +
 	"\vrunner_sets\x18\x01 \x03(\v2\x1a.controlplane.v1.RunnerSetR\n" +
@@ -898,48 +1104,56 @@ func file_controlplane_v1_controlplane_proto_rawDescGZIP() []byte {
 }
 
 var file_controlplane_v1_controlplane_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_controlplane_v1_controlplane_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_controlplane_v1_controlplane_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_controlplane_v1_controlplane_proto_goTypes = []any{
 	(Backend)(0),                     // 0: controlplane.v1.Backend
 	(RunnerState)(0),                 // 1: controlplane.v1.RunnerState
 	(JobResult)(0),                   // 2: controlplane.v1.JobResult
 	(*GetServiceInfoRequest)(nil),    // 3: controlplane.v1.GetServiceInfoRequest
 	(*GetServiceInfoResponse)(nil),   // 4: controlplane.v1.GetServiceInfoResponse
-	(*ListRunnerSetsRequest)(nil),    // 5: controlplane.v1.ListRunnerSetsRequest
-	(*ListRunnerSetsResponse)(nil),   // 6: controlplane.v1.ListRunnerSetsResponse
-	(*RunnerSet)(nil),                // 7: controlplane.v1.RunnerSet
-	(*Runner)(nil),                   // 8: controlplane.v1.Runner
-	(*ListJobRecordsRequest)(nil),    // 9: controlplane.v1.ListJobRecordsRequest
-	(*ListJobRecordsResponse)(nil),   // 10: controlplane.v1.ListJobRecordsResponse
-	(*JobRecord)(nil),                // 11: controlplane.v1.JobRecord
-	(*GetMachineVitalsRequest)(nil),  // 12: controlplane.v1.GetMachineVitalsRequest
-	(*GetMachineVitalsResponse)(nil), // 13: controlplane.v1.GetMachineVitalsResponse
-	(*timestamppb.Timestamp)(nil),    // 14: google.protobuf.Timestamp
+	(*BuildInfo)(nil),                // 5: controlplane.v1.BuildInfo
+	(*Module)(nil),                   // 6: controlplane.v1.Module
+	(*BuildSetting)(nil),             // 7: controlplane.v1.BuildSetting
+	(*ListRunnerSetsRequest)(nil),    // 8: controlplane.v1.ListRunnerSetsRequest
+	(*ListRunnerSetsResponse)(nil),   // 9: controlplane.v1.ListRunnerSetsResponse
+	(*RunnerSet)(nil),                // 10: controlplane.v1.RunnerSet
+	(*Runner)(nil),                   // 11: controlplane.v1.Runner
+	(*ListJobRecordsRequest)(nil),    // 12: controlplane.v1.ListJobRecordsRequest
+	(*ListJobRecordsResponse)(nil),   // 13: controlplane.v1.ListJobRecordsResponse
+	(*JobRecord)(nil),                // 14: controlplane.v1.JobRecord
+	(*GetMachineVitalsRequest)(nil),  // 15: controlplane.v1.GetMachineVitalsRequest
+	(*GetMachineVitalsResponse)(nil), // 16: controlplane.v1.GetMachineVitalsResponse
+	(*timestamppb.Timestamp)(nil),    // 17: google.protobuf.Timestamp
 }
 var file_controlplane_v1_controlplane_proto_depIdxs = []int32{
-	14, // 0: controlplane.v1.GetServiceInfoResponse.started_at:type_name -> google.protobuf.Timestamp
-	7,  // 1: controlplane.v1.ListRunnerSetsResponse.runner_sets:type_name -> controlplane.v1.RunnerSet
-	0,  // 2: controlplane.v1.RunnerSet.backend:type_name -> controlplane.v1.Backend
-	8,  // 3: controlplane.v1.RunnerSet.runners:type_name -> controlplane.v1.Runner
-	1,  // 4: controlplane.v1.Runner.state:type_name -> controlplane.v1.RunnerState
-	14, // 5: controlplane.v1.Runner.since:type_name -> google.protobuf.Timestamp
-	11, // 6: controlplane.v1.ListJobRecordsResponse.job_records:type_name -> controlplane.v1.JobRecord
-	2,  // 7: controlplane.v1.JobRecord.result:type_name -> controlplane.v1.JobResult
-	14, // 8: controlplane.v1.JobRecord.started_at:type_name -> google.protobuf.Timestamp
-	14, // 9: controlplane.v1.JobRecord.completed_at:type_name -> google.protobuf.Timestamp
-	3,  // 10: controlplane.v1.ControlPlaneService.GetServiceInfo:input_type -> controlplane.v1.GetServiceInfoRequest
-	5,  // 11: controlplane.v1.ControlPlaneService.ListRunnerSets:input_type -> controlplane.v1.ListRunnerSetsRequest
-	9,  // 12: controlplane.v1.ControlPlaneService.ListJobRecords:input_type -> controlplane.v1.ListJobRecordsRequest
-	12, // 13: controlplane.v1.ControlPlaneService.GetMachineVitals:input_type -> controlplane.v1.GetMachineVitalsRequest
-	4,  // 14: controlplane.v1.ControlPlaneService.GetServiceInfo:output_type -> controlplane.v1.GetServiceInfoResponse
-	6,  // 15: controlplane.v1.ControlPlaneService.ListRunnerSets:output_type -> controlplane.v1.ListRunnerSetsResponse
-	10, // 16: controlplane.v1.ControlPlaneService.ListJobRecords:output_type -> controlplane.v1.ListJobRecordsResponse
-	13, // 17: controlplane.v1.ControlPlaneService.GetMachineVitals:output_type -> controlplane.v1.GetMachineVitalsResponse
-	14, // [14:18] is the sub-list for method output_type
-	10, // [10:14] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	5,  // 0: controlplane.v1.GetServiceInfoResponse.build_info:type_name -> controlplane.v1.BuildInfo
+	17, // 1: controlplane.v1.GetServiceInfoResponse.started_at:type_name -> google.protobuf.Timestamp
+	6,  // 2: controlplane.v1.BuildInfo.main:type_name -> controlplane.v1.Module
+	6,  // 3: controlplane.v1.BuildInfo.deps:type_name -> controlplane.v1.Module
+	7,  // 4: controlplane.v1.BuildInfo.settings:type_name -> controlplane.v1.BuildSetting
+	6,  // 5: controlplane.v1.Module.replace:type_name -> controlplane.v1.Module
+	10, // 6: controlplane.v1.ListRunnerSetsResponse.runner_sets:type_name -> controlplane.v1.RunnerSet
+	0,  // 7: controlplane.v1.RunnerSet.backend:type_name -> controlplane.v1.Backend
+	11, // 8: controlplane.v1.RunnerSet.runners:type_name -> controlplane.v1.Runner
+	1,  // 9: controlplane.v1.Runner.state:type_name -> controlplane.v1.RunnerState
+	17, // 10: controlplane.v1.Runner.since:type_name -> google.protobuf.Timestamp
+	14, // 11: controlplane.v1.ListJobRecordsResponse.job_records:type_name -> controlplane.v1.JobRecord
+	2,  // 12: controlplane.v1.JobRecord.result:type_name -> controlplane.v1.JobResult
+	17, // 13: controlplane.v1.JobRecord.started_at:type_name -> google.protobuf.Timestamp
+	17, // 14: controlplane.v1.JobRecord.completed_at:type_name -> google.protobuf.Timestamp
+	3,  // 15: controlplane.v1.ControlPlaneService.GetServiceInfo:input_type -> controlplane.v1.GetServiceInfoRequest
+	8,  // 16: controlplane.v1.ControlPlaneService.ListRunnerSets:input_type -> controlplane.v1.ListRunnerSetsRequest
+	12, // 17: controlplane.v1.ControlPlaneService.ListJobRecords:input_type -> controlplane.v1.ListJobRecordsRequest
+	15, // 18: controlplane.v1.ControlPlaneService.GetMachineVitals:input_type -> controlplane.v1.GetMachineVitalsRequest
+	4,  // 19: controlplane.v1.ControlPlaneService.GetServiceInfo:output_type -> controlplane.v1.GetServiceInfoResponse
+	9,  // 20: controlplane.v1.ControlPlaneService.ListRunnerSets:output_type -> controlplane.v1.ListRunnerSetsResponse
+	13, // 21: controlplane.v1.ControlPlaneService.ListJobRecords:output_type -> controlplane.v1.ListJobRecordsResponse
+	16, // 22: controlplane.v1.ControlPlaneService.GetMachineVitals:output_type -> controlplane.v1.GetMachineVitalsResponse
+	19, // [19:23] is the sub-list for method output_type
+	15, // [15:19] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_controlplane_v1_controlplane_proto_init() }
@@ -947,14 +1161,14 @@ func file_controlplane_v1_controlplane_proto_init() {
 	if File_controlplane_v1_controlplane_proto != nil {
 		return
 	}
-	file_controlplane_v1_controlplane_proto_msgTypes[8].OneofWrappers = []any{}
+	file_controlplane_v1_controlplane_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_controlplane_v1_controlplane_proto_rawDesc), len(file_controlplane_v1_controlplane_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   11,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/boring-design/elastic-fruit-runner/dashboard"
 	controlplanev1 "github.com/boring-design/elastic-fruit-runner/gen/controlplane/v1"
 	"github.com/boring-design/elastic-fruit-runner/gen/controlplane/v1/controlplanev1connect"
+	"github.com/boring-design/elastic-fruit-runner/internal/buildinfo"
 	"github.com/boring-design/elastic-fruit-runner/internal/controller"
 	"github.com/boring-design/elastic-fruit-runner/internal/management"
 	"github.com/boring-design/elastic-fruit-runner/internal/vitals"
@@ -60,12 +62,50 @@ func (s *Server) Handler() http.Handler {
 }
 
 func (s *Server) GetServiceInfo(_ context.Context, _ *connect.Request[controlplanev1.GetServiceInfoRequest]) (*connect.Response[controlplanev1.GetServiceInfoResponse], error) {
+	build := buildinfo.Current()
 	return connect.NewResponse(&controlplanev1.GetServiceInfoResponse{
-		Version:            controller.Version,
-		CommitSha:          controller.CommitSHA,
+		BuildInfo:          toProtoBuildInfo(build),
 		StartedAt:          timestamppb.New(s.vitalsService.StartedAt()),
 		IdleTimeoutSeconds: int32(s.idleTimeout.Seconds()),
 	}), nil
+}
+
+func toProtoBuildInfo(bi *debug.BuildInfo) *controlplanev1.BuildInfo {
+	if bi == nil {
+		return nil
+	}
+
+	deps := make([]*controlplanev1.Module, 0, len(bi.Deps))
+	for _, dep := range bi.Deps {
+		deps = append(deps, toProtoModule(dep))
+	}
+	settings := make([]*controlplanev1.BuildSetting, 0, len(bi.Settings))
+	for _, setting := range bi.Settings {
+		settings = append(settings, &controlplanev1.BuildSetting{
+			Key:   setting.Key,
+			Value: setting.Value,
+		})
+	}
+
+	return &controlplanev1.BuildInfo{
+		GoVersion: bi.GoVersion,
+		Path:      bi.Path,
+		Main:      toProtoModule(&bi.Main),
+		Deps:      deps,
+		Settings:  settings,
+	}
+}
+
+func toProtoModule(module *debug.Module) *controlplanev1.Module {
+	if module == nil {
+		return nil
+	}
+	return &controlplanev1.Module{
+		Path:    module.Path,
+		Version: module.Version,
+		Sum:     module.Sum,
+		Replace: toProtoModule(module.Replace),
+	}
 }
 
 func (s *Server) ListRunnerSets(_ context.Context, _ *connect.Request[controlplanev1.ListRunnerSetsRequest]) (*connect.Response[controlplanev1.ListRunnerSetsResponse], error) {

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,50 @@
+package buildinfo
+
+import "runtime/debug"
+
+const (
+	defaultVersion   = "dev"
+	defaultCommitSHA = "unknown"
+)
+
+// Current returns the Go build metadata embedded in the running binary.
+func Current() *debug.BuildInfo {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	return bi
+}
+
+// MainVersion returns the main module version from Go build info.
+func MainVersion(bi *debug.BuildInfo) string {
+	if bi == nil {
+		return defaultVersion
+	}
+	if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		return bi.Main.Version
+	}
+	return defaultVersion
+}
+
+// VCSRevision returns the Git revision from Go build settings.
+func VCSRevision(bi *debug.BuildInfo) string {
+	revision := Setting(bi, "vcs.revision")
+	if revision == "" {
+		return defaultCommitSHA
+	}
+	return revision
+}
+
+// Setting returns a single build setting value by key.
+func Setting(bi *debug.BuildInfo, key string) string {
+	if bi == nil {
+		return ""
+	}
+	for _, setting := range bi.Settings {
+		if setting.Key == key {
+			return setting.Value
+		}
+	}
+	return ""
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,45 @@
+package buildinfo_test
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/boring-design/elastic-fruit-runner/internal/buildinfo"
+)
+
+func TestMainVersionUsesBuildInfoMainVersion(t *testing.T) {
+	t.Parallel()
+
+	bi := &debug.BuildInfo{
+		Main: debug.Module{
+			Version: "v1.2.3",
+		},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0123456789abcdef"},
+		},
+	}
+
+	if got := buildinfo.MainVersion(bi); got != "v1.2.3" {
+		t.Fatalf("MainVersion() = %q, want %q", got, "v1.2.3")
+	}
+	if got := buildinfo.VCSRevision(bi); got != "0123456789abcdef" {
+		t.Fatalf("VCSRevision() = %q, want %q", got, "0123456789abcdef")
+	}
+}
+
+func TestMainVersionFallsBackForDevelopmentBuilds(t *testing.T) {
+	t.Parallel()
+
+	bi := &debug.BuildInfo{
+		Main: debug.Module{
+			Version: "(devel)",
+		},
+	}
+
+	if got := buildinfo.MainVersion(bi); got != "dev" {
+		t.Fatalf("MainVersion() = %q, want %q", got, "dev")
+	}
+	if got := buildinfo.VCSRevision(bi); got != "unknown" {
+		t.Fatalf("VCSRevision() = %q, want %q", got, "unknown")
+	}
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -15,15 +15,10 @@ import (
 
 	"github.com/boring-design/elastic-fruit-runner/config"
 	"github.com/boring-design/elastic-fruit-runner/internal/backend"
+	"github.com/boring-design/elastic-fruit-runner/internal/buildinfo"
 )
 
 var tracer = otel.Tracer("github.com/boring-design/elastic-fruit-runner/internal/controller")
-
-// Version and CommitSHA are set at build time via -ldflags.
-var (
-	Version   = "dev"
-	CommitSHA = "unknown"
-)
 
 // ScaleSetController registers a GitHub Actions Runner Scale Set, polls for
 // job assignments via the listener, and manages the lifecycle of ephemeral
@@ -116,11 +111,12 @@ func (d *ScaleSetController) Run(ctx context.Context) error {
 	d.scaleSetID = ss.ID
 	d.logger.Info("scale set ready", "id", ss.ID, "name", ss.Name)
 
+	build := buildinfo.Current()
 	d.client.SetSystemInfo(scaleset.SystemInfo{
 		System:     "elastic-fruit-runner",
 		Subsystem:  "controller",
-		Version:    Version,
-		CommitSHA:  CommitSHA,
+		Version:    buildinfo.MainVersion(build),
+		CommitSHA:  buildinfo.VCSRevision(build),
 		ScaleSetID: ss.ID,
 	})
 

--- a/proto/controlplane/v1/controlplane.proto
+++ b/proto/controlplane/v1/controlplane.proto
@@ -31,14 +31,37 @@ service ControlPlaneService {
 message GetServiceInfoRequest {}
 
 message GetServiceInfoResponse {
-  // Semantic version set at build time via -ldflags.
-  string version = 1;
-  // Git commit hash set at build time via -ldflags.
-  string commit_sha = 2;
+  // Go build metadata embedded in the daemon binary.
+  BuildInfo build_info = 1;
   // When the daemon process started.
-  google.protobuf.Timestamp started_at = 3;
+  google.protobuf.Timestamp started_at = 2;
   // Configured idle runner timeout in seconds.
-  int32 idle_timeout_seconds = 4;
+  int32 idle_timeout_seconds = 3;
+}
+
+message BuildInfo {
+  // Go toolchain version used to build the binary.
+  string go_version = 1;
+  // Main package path.
+  string path = 2;
+  // Main module.
+  Module main = 3;
+  // Dependency modules.
+  repeated Module deps = 4;
+  // Build settings such as VCS metadata.
+  repeated BuildSetting settings = 5;
+}
+
+message Module {
+  string path = 1;
+  string version = 2;
+  string sum = 3;
+  Module replace = 4;
+}
+
+message BuildSetting {
+  string key = 1;
+  string value = 2;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace hand-rolled controller version and commit globals with Go's embedded build info.
- Change GetServiceInfo to expose a build_info object shaped after runtime/debug.BuildInfo: goVersion, path, main, deps, and settings.
- Keep GitHub scale set system info derived from the standard-library build info without introducing a local Info wrapper.
- Update dashboard status parsing/display to read build metadata from buildInfo.

## Why

Go already embeds module and VCS metadata in binaries built with module support. Returning that shape through the API avoids maintaining a parallel version/commit projection and keeps local, release, and VCS-aware builds on one path.

## Validation

- buf generate
- buf lint
- cd dashboard && pnpm install --frozen-lockfile
- cd dashboard && pnpm run build
- go test ./internal/api
- go test ./gen/controlplane/v1 ./internal/buildinfo ./internal/controller
- cd dashboard && pnpm exec tsc -p tsconfig.app.json --noEmit
- cd dashboard && pnpm run lint
- prek run --all-files

## Notes

The original draft PR #74 was closed because its branch included unrelated commits. This PR uses a clean branch based on main.