### PR TITLE
fix(dashboard): derive operational state, surface scope per set, show real refresh cadence

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -7,6 +7,14 @@ import { SystemVitals } from './components/SystemVitals'
 import { RunnerSetPanel } from './components/RunnerSetPanel'
 import { JobRow } from './components/JobRow'
 import { ConnectionStatus } from './components/ConnectionStatus'
+import type { DashboardStatus } from './derived/status'
+
+const STATUS_TONE_COLOR: Record<DashboardStatus['tone'], string> = {
+  neutral: '#f0f0f0',
+  active: '#f0f0f0',
+  warning: '#ff9500',
+  error: '#ff3b30',
+}
 
 function formatBuildVersion(version: string) {
   if (!version) return 'unknown'
@@ -33,6 +41,9 @@ export default function App() {
     failureCount,
     canceledCount,
     mood,
+    status,
+    refreshIntervalSeconds,
+    secondsUntilRefresh,
   } = useDashboardDerived()
 
   if (error) {
@@ -84,26 +95,16 @@ export default function App() {
           <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 16 }}>
             <div className="spinner" />
             <div>
-              <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: '0.05em', marginBottom: 4, color: '#f0f0f0' }}>
-                LISTENING FOR JOBS
+              <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: '0.05em', marginBottom: 4, color: STATUS_TONE_COLOR[status.tone] }}>
+                {status.label}
               </div>
               <div style={{ fontSize: 9, color: '#555', letterSpacing: '0.1em' }}>
-                GITHUB SCALE SET API
+                {status.detail}
               </div>
             </div>
           </div>
 
           <div style={{ borderTop: '1px solid #1e1e1e', paddingTop: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {/* Scope */}
-            <div>
-              <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>CONNECTED TO</div>
-              {runnerSets.map(rs => (
-                <div key={rs.name} style={{ fontSize: 11, color: '#888', letterSpacing: '0.04em' }}>
-                  {rs.scope}
-                </div>
-              )).filter((_, i) => i === 0)}
-            </div>
-
             {/* Auth + Sets */}
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
               <div>
@@ -280,9 +281,10 @@ export default function App() {
       </div>
 
       {/* ── Footer ── */}
-      <div style={{ marginTop: 20, display: 'flex', justifyContent: 'space-between', color: '#333', fontSize: 10, letterSpacing: '0.12em' }}>
-        <span>SCOPE: {runnerSets[0]?.scope.toUpperCase()}</span>
-        <span>AUTO-REFRESH 1S<span className="blink">_</span></span>
+      <div style={{ marginTop: 20, display: 'flex', justifyContent: 'flex-end', color: '#333', fontSize: 10, letterSpacing: '0.12em' }}>
+        <span>
+          AUTO-REFRESH {refreshIntervalSeconds}S · NEXT IN {secondsUntilRefresh}S<span className="blink">_</span>
+        </span>
       </div>
     </div>
   )

--- a/dashboard/src/components/RunnerSetPanel.tsx
+++ b/dashboard/src/components/RunnerSetPanel.tsx
@@ -51,6 +51,16 @@ export function RunnerSetPanel({ rs, now }: { rs: RunnerSet; now: Date }) {
         </span>
       </div>
 
+      {/* Scope + connection */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4, gap: 8 }}>
+        <span style={{ color: '#888', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}>
+          SCOPE: {rs.scope}
+        </span>
+        <span style={{ color: rs.connected ? '#7cb87c' : '#ff3b30', fontSize: 10, letterSpacing: '0.12em', flexShrink: 0 }}>
+          {rs.connected ? 'CONNECTED' : 'DISCONNECTED'}
+        </span>
+      </div>
+
       {/* Image */}
       <div style={{ color: '#555', fontSize: 10, marginBottom: 10, letterSpacing: '0.04em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
         {rs.image}

--- a/dashboard/src/config.ts
+++ b/dashboard/src/config.ts
@@ -1,0 +1,5 @@
+// REFRESH_INTERVAL_MS is the shared polling cadence for all dashboard data.
+// It governs both the SWR refetch loop in useDashboardSync and the
+// AUTO-REFRESH countdown rendered in the footer so the displayed value
+// always matches the real schedule.
+export const REFRESH_INTERVAL_MS = 5000

--- a/dashboard/src/derived/status.ts
+++ b/dashboard/src/derived/status.ts
@@ -1,0 +1,99 @@
+import type { RunnerSet } from '../types'
+
+export type DashboardStatusKind =
+  | 'loading'
+  | 'disconnected'
+  | 'connecting'
+  | 'scaling-up'
+  | 'processing'
+  | 'listening'
+  | 'idle'
+
+export interface DashboardStatus {
+  kind: DashboardStatusKind
+  label: string
+  detail: string
+  tone: 'neutral' | 'active' | 'warning' | 'error'
+}
+
+const STATUS_DETAIL: Record<DashboardStatusKind, string> = {
+  loading: 'AWAITING DATA',
+  disconnected: 'CONTROLLER OFFLINE',
+  connecting: 'GITHUB SCALE SET API',
+  'scaling-up': 'PREPARING NEW RUNNERS',
+  processing: 'RUNNERS EXECUTING JOBS',
+  listening: 'GITHUB SCALE SET API',
+  idle: 'GITHUB SCALE SET API',
+}
+
+const STATUS_LABEL: Record<DashboardStatusKind, string> = {
+  loading: 'INITIALIZING',
+  disconnected: 'DISCONNECTED',
+  connecting: 'CONNECTING',
+  'scaling-up': 'SCALING UP',
+  processing: 'PROCESSING',
+  listening: 'LISTENING FOR JOBS',
+  idle: 'IDLE',
+}
+
+const STATUS_TONE: Record<DashboardStatusKind, DashboardStatus['tone']> = {
+  loading: 'neutral',
+  disconnected: 'error',
+  connecting: 'warning',
+  'scaling-up': 'active',
+  processing: 'active',
+  listening: 'neutral',
+  idle: 'neutral',
+}
+
+function buildStatus(kind: DashboardStatusKind): DashboardStatus {
+  return {
+    kind,
+    label: STATUS_LABEL[kind],
+    detail: STATUS_DETAIL[kind],
+    tone: STATUS_TONE[kind],
+  }
+}
+
+// deriveDashboardStatus collapses the controller's runner-set view into a
+// single high-level operational status the dashboard can render.
+//
+// Rules (in priority order):
+//   1. No runner-set data yet -> loading.
+//   2. Every set reports disconnected -> disconnected.
+//   3. At least one set is disconnected (mixed) -> connecting.
+//   4. Any runner is preparing -> scaling-up.
+//   5. Any runner is busy -> processing.
+//   6. Any runner is idle -> listening.
+//   7. No runners at all -> idle.
+export function deriveDashboardStatus(runnerSets: RunnerSet[]): DashboardStatus {
+  if (runnerSets.length === 0) {
+    return buildStatus('loading')
+  }
+
+  const connectedCount = runnerSets.filter(rs => rs.connected).length
+  if (connectedCount === 0) {
+    return buildStatus('disconnected')
+  }
+  if (connectedCount < runnerSets.length) {
+    return buildStatus('connecting')
+  }
+
+  const allRunners = runnerSets.flatMap(rs => rs.runners)
+  const hasPreparing = allRunners.some(r => r.state === 'preparing')
+  if (hasPreparing) {
+    return buildStatus('scaling-up')
+  }
+
+  const hasBusy = allRunners.some(r => r.state === 'busy')
+  if (hasBusy) {
+    return buildStatus('processing')
+  }
+
+  const hasIdle = allRunners.some(r => r.state === 'idle')
+  if (hasIdle) {
+    return buildStatus('listening')
+  }
+
+  return buildStatus('idle')
+}

--- a/dashboard/src/hooks/useDashboardDerived.ts
+++ b/dashboard/src/hooks/useDashboardDerived.ts
@@ -1,9 +1,11 @@
 import { useDashboardStore } from '../store/useDashboardStore'
 import { elapsed } from '../utils'
+import { REFRESH_INTERVAL_MS } from '../config'
 import type { PetMood } from '../components/petMood'
+import { deriveDashboardStatus } from '../derived/status'
 
 export function useDashboardDerived() {
-  const { daemonStatus, runnerSets, recentJobs, machineVitals, now } = useDashboardStore()
+  const { daemonStatus, runnerSets, recentJobs, machineVitals, now, lastSyncedAt } = useDashboardStore()
 
   const uptime = daemonStatus ? elapsed(daemonStatus.startedAt, now) : 0
 
@@ -26,6 +28,18 @@ export function useDashboardDerived() {
     idle > 0      ? 'idle'  :
     'sleeping'
 
+  const status = deriveDashboardStatus(runnerSets)
+
+  const refreshIntervalSeconds = Math.max(1, Math.round(REFRESH_INTERVAL_MS / 1000))
+  let secondsUntilRefresh = refreshIntervalSeconds
+  if (lastSyncedAt) {
+    const sinceLastSync = elapsed(lastSyncedAt, now)
+    const remaining = refreshIntervalSeconds - sinceLastSync
+    secondsUntilRefresh = remaining < 0
+      ? 0
+      : Math.min(remaining, refreshIntervalSeconds)
+  }
+
   return {
     daemonStatus,
     runnerSets,
@@ -43,5 +57,8 @@ export function useDashboardDerived() {
     failureCount,
     canceledCount,
     mood,
+    status,
+    refreshIntervalSeconds,
+    secondsUntilRefresh,
   }
 }

--- a/dashboard/src/hooks/useDashboardSync.ts
+++ b/dashboard/src/hooks/useDashboardSync.ts
@@ -2,30 +2,48 @@ import { useEffect } from 'react'
 import useSWR from 'swr'
 import { useDashboardStore } from '../store/useDashboardStore'
 import { fetchDaemonStatus, fetchRunnerSets, fetchRecentJobs, fetchMachineVitals } from '../api/fetchers'
-
-const REFRESH_INTERVAL = 5000
+import { REFRESH_INTERVAL_MS } from '../config'
 
 export function useDashboardSync() {
-  const { setDaemonStatus, setRunnerSets, setRecentJobs, setMachineVitals, tick } = useDashboardStore()
+  const {
+    setDaemonStatus,
+    setRunnerSets,
+    setRecentJobs,
+    setMachineVitals,
+    markSynced,
+    tick,
+  } = useDashboardStore()
 
   const status = useSWR('daemonStatus', fetchDaemonStatus, {
-    refreshInterval: REFRESH_INTERVAL,
-    onSuccess: setDaemonStatus,
+    refreshInterval: REFRESH_INTERVAL_MS,
+    onSuccess: (data) => {
+      setDaemonStatus(data)
+      markSynced()
+    },
   })
 
   const sets = useSWR('runnerSets', fetchRunnerSets, {
-    refreshInterval: REFRESH_INTERVAL,
-    onSuccess: setRunnerSets,
+    refreshInterval: REFRESH_INTERVAL_MS,
+    onSuccess: (data) => {
+      setRunnerSets(data)
+      markSynced()
+    },
   })
 
   const jobs = useSWR('recentJobs', fetchRecentJobs, {
-    refreshInterval: REFRESH_INTERVAL,
-    onSuccess: setRecentJobs,
+    refreshInterval: REFRESH_INTERVAL_MS,
+    onSuccess: (data) => {
+      setRecentJobs(data)
+      markSynced()
+    },
   })
 
   const vitals = useSWR('machineVitals', fetchMachineVitals, {
-    refreshInterval: REFRESH_INTERVAL,
-    onSuccess: setMachineVitals,
+    refreshInterval: REFRESH_INTERVAL_MS,
+    onSuccess: (data) => {
+      setMachineVitals(data)
+      markSynced()
+    },
   })
 
   useEffect(() => {

--- a/dashboard/src/store/useDashboardStore.ts
+++ b/dashboard/src/store/useDashboardStore.ts
@@ -8,11 +8,15 @@ export interface DashboardState {
   recentJobs: JobRecord[]
   machineVitals: MachineVitals | null
   now: Date
+  // Timestamp of the most recent successful poll cycle. Used by the footer
+  // AUTO-REFRESH countdown so the displayed timer reflects the real cadence.
+  lastSyncedAt: Date | null
 
   setDaemonStatus: (status: DaemonStatus) => void
   setRunnerSets: (sets: RunnerSet[]) => void
   setRecentJobs: (jobs: JobRecord[]) => void
   setMachineVitals: (vitals: MachineVitals) => void
+  markSynced: () => void
   tick: () => void
 }
 
@@ -24,11 +28,13 @@ export const useDashboardStore = create<DashboardState>()(
       recentJobs: [],
       machineVitals: null,
       now: new Date(),
+      lastSyncedAt: null,
 
       setDaemonStatus: (status) => set({ daemonStatus: status }, false, 'setDaemonStatus'),
       setRunnerSets: (sets) => set({ runnerSets: sets }, false, 'setRunnerSets'),
       setRecentJobs: (jobs) => set({ recentJobs: jobs }, false, 'setRecentJobs'),
       setMachineVitals: (vitals) => set({ machineVitals: vitals }, false, 'setMachineVitals'),
+      markSynced: () => set({ lastSyncedAt: new Date() }, false, 'markSynced'),
       tick: () => set({ now: new Date() }, false, 'tick'),
     }),
     { name: 'dashboard' },


### PR DESCRIPTION
## Summary
- Replace hardcoded `LISTENING FOR JOBS` status text and `AUTO-REFRESH 1S` footer with values derived from the live `ListRunnerSets` view and the real polling cadence.
- Add `deriveDashboardStatus` pure helper that maps controller connection state plus runner state counts onto `disconnected` / `connecting` / `scaling-up` / `processing` / `listening` / `idle` (plus an initial `loading` state) with an associated tone the UI uses for color.
- Track `lastSyncedAt` in the Zustand store, share `REFRESH_INTERVAL_MS` between the SWR loop and `useDashboardDerived`, and surface a real `NEXT IN Ns` countdown alongside the configured interval.
- Move `SCOPE` from the single global footer line onto each runner-set panel and add a per-set `CONNECTED` / `DISCONNECTED` indicator.

No backend / proto changes were needed: every signal already shipped over `GetServiceInfo` + `ListRunnerSets`. `#58` and `#61` collapsed into a single fix because the offending text was the same hardcoded `LISTENING FOR JOBS` string in the STATUS card.

Fixes #58
Fixes #61
Fixes #63
Fixes #64

## Test plan
- [x] `make check` (fmt-check + vet + build + lint + prek + unit-test)
- [x] `pnpm run build` and `pnpm run lint` inside `dashboard/`
- [ ] Manual: load dashboard against a daemon with mixed runner states; confirm STATUS card transitions through `SCALING UP` -> `PROCESSING` -> `LISTENING FOR JOBS` -> `IDLE` and `DISCONNECTED` when the controller drops its scale-set connection.
- [ ] Manual: confirm AUTO-REFRESH footer counts down `5S -> 0S` and resets after each successful poll.
- [ ] Manual: confirm SCOPE is rendered per runner-set panel and absent from the global footer.