### PR TITLE
fix(dashboard): tighten layout, fix name truncation, clarify controller card

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -2,7 +2,7 @@ import { useDashboardSync } from './hooks/useDashboardSync'
 import { useDashboardDerived } from './hooks/useDashboardDerived'
 import { elapsed, fmtDuration, fmtUptime } from './utils'
 import { PixelPet } from './components/PixelPet'
-import { MOOD_LABEL, MOOD_SUBTEXT } from './components/petMood'
+import { MOOD_LABEL, MOOD_SUBTEXT, MOOD_TOOLTIP } from './components/petMood'
 import { SystemVitals } from './components/SystemVitals'
 import { RunnerSetPanel } from './components/RunnerSetPanel'
 import { JobRow } from './components/JobRow'
@@ -81,45 +81,36 @@ export default function App() {
         {/* Cell: Daemon status */}
         <div className="cell">
           <div className="label">STATUS</div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 16 }}>
+          <div className="status-hero">
             <div className="spinner" />
             <div>
-              <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: '0.05em', marginBottom: 4, color: '#f0f0f0' }}>
-                LISTENING FOR JOBS
-              </div>
-              <div style={{ fontSize: 9, color: '#555', letterSpacing: '0.1em' }}>
-                GITHUB SCALE SET API
-              </div>
+              <div className="status-hero-title">LISTENING FOR JOBS</div>
+              <div className="status-hero-sub">GITHUB SCALE SET API</div>
             </div>
           </div>
 
-          <div style={{ borderTop: '1px solid #1e1e1e', paddingTop: 14, display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {/* Scope */}
+          <div className="status-meta">
             <div>
-              <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>CONNECTED TO</div>
-              {runnerSets.map(rs => (
-                <div key={rs.name} style={{ fontSize: 11, color: '#888', letterSpacing: '0.04em' }}>
-                  {rs.scope}
-                </div>
-              )).filter((_, i) => i === 0)}
-            </div>
-
-            {/* Auth + Sets */}
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-              <div>
-                <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>AUTH MODE</div>
-                <div style={{ fontSize: 11, color: '#888' }}>GITHUB APP</div>
-              </div>
-              <div>
-                <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>RUNNER SETS</div>
-                <div style={{ fontSize: 18, fontWeight: 700, color: '#f0f0f0', lineHeight: 1 }}>{runnerSets.length}</div>
+              <div className="meta-label">CONNECTED TO</div>
+              <div className="meta-value ellipsis" title={runnerSets[0]?.scope ?? ''}>
+                {runnerSets[0]?.scope ?? '—'}
               </div>
             </div>
 
-            {/* Last activity */}
+            <div className="status-meta-row">
+              <div>
+                <div className="meta-label">AUTH MODE</div>
+                <div className="meta-value">GITHUB APP</div>
+              </div>
+              <div>
+                <div className="meta-label">RUNNER SETS</div>
+                <div className="meta-strong">{runnerSets.length}</div>
+              </div>
+            </div>
+
             <div>
-              <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>LAST JOB</div>
-              <div style={{ fontSize: 11, color: '#888' }}>
+              <div className="meta-label">LAST JOB</div>
+              <div className="meta-value">
                 {(() => {
                   const latest = recentJobs.find(j => j.completedAt)
                   if (!latest?.completedAt) return '—'
@@ -143,31 +134,29 @@ export default function App() {
             <span className="value-md">{totalActive}</span>
             <span style={{ fontSize: 11, color: '#555' }}>OF {totalMax} MAX</span>
           </div>
-          <div style={{ fontSize: 10, color: '#555', letterSpacing: '0.12em', marginBottom: 16 }}>
-            OVERALL UTILIZATION {utilPct}% · {totalMax - totalActive} SLOTS FREE
+          <div className="capacity-sub">
+            {utilPct}% UTILIZED · {totalMax - totalActive} SLOTS FREE
           </div>
 
           {/* Per-set breakdown */}
-          <div style={{ borderTop: '1px solid #1e1e1e', paddingTop: 14 }}>
-            <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 10 }}>PER SET</div>
+          <div className="capacity-section">
+            <div className="meta-label" style={{ marginBottom: 8 }}>PER SET</div>
             {runnerSets.map(rs => {
               const pct = Math.round((rs.runners.length / rs.maxRunners) * 100)
               return (
-                <div key={rs.name} style={{ marginBottom: 10 }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
-                    <span style={{ fontSize: 10, color: '#888', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '70%' }}>
+                <div key={rs.name} className="capacity-set">
+                  <div className="capacity-set-head">
+                    <span className="ellipsis" title={rs.name} style={{ fontSize: 10, color: '#888', minWidth: 0 }}>
                       {rs.name}
                     </span>
                     <span style={{ fontSize: 10, color: '#555', flexShrink: 0 }}>
                       {rs.runners.length}/{rs.maxRunners}
                     </span>
                   </div>
-                  <div style={{ height: 4, background: '#1a1a1a', overflow: 'hidden' }}>
-                    <div style={{
-                      height: '100%', width: `${pct}%`,
+                  <div className="capacity-set-bar">
+                    <div className="capacity-set-fill" style={{
+                      width: `${pct}%`,
                       background: pct >= 80 ? '#ff9500' : '#e8e8e8',
-                      transition: 'width 0.6s ease',
-                      backgroundImage: 'repeating-linear-gradient(90deg, transparent 0px, transparent 3px, rgba(0,0,0,0.35) 3px, rgba(0,0,0,0.35) 4px)',
                     }} />
                   </div>
                 </div>
@@ -176,10 +165,10 @@ export default function App() {
           </div>
 
           {/* Throughput stats */}
-          <div style={{ borderTop: '1px solid #1e1e1e', paddingTop: 14, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div className="capacity-section throughput">
             <div>
-              <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>AVG DURATION</div>
-              <div style={{ fontSize: 16, fontWeight: 700, color: '#f0f0f0' }}>
+              <div className="meta-label">AVG DURATION</div>
+              <div className="meta-strong">
                 {(() => {
                   const done = recentJobs.filter(j => j.completedAt)
                   if (!done.length) return '—'
@@ -189,8 +178,8 @@ export default function App() {
               </div>
             </div>
             <div>
-              <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.15em', marginBottom: 3 }}>SUCCESS RATE</div>
-              <div style={{ fontSize: 16, fontWeight: 700, color: successCount + failureCount + canceledCount > 0 && (failureCount + canceledCount) / (successCount + failureCount + canceledCount) > 0.2 ? '#ff9500' : '#f0f0f0' }}>
+              <div className="meta-label">SUCCESS RATE</div>
+              <div className="meta-strong" style={{ color: successCount + failureCount + canceledCount > 0 && (failureCount + canceledCount) / (successCount + failureCount + canceledCount) > 0.2 ? '#ff9500' : '#f0f0f0' }}>
                 {successCount + failureCount + canceledCount > 0
                   ? `${Math.round(successCount / (successCount + failureCount + canceledCount) * 100)}%`
                   : '—'}
@@ -199,37 +188,50 @@ export default function App() {
           </div>
         </div>
 
-        {/* Cell: BRAIN — pixel pet + vitals */}
+        {/* Cell: CONTROLLER — pixel pet + uptime + vitals */}
         <div className="cell cell-brain">
-          <div className="label">RUNNER BRAIN</div>
-          <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
+          <div className="label" title="Live state of the controller process and host machine">
+            CONTROLLER
+          </div>
+          <div className="brain-pet-row">
             {/* Pixel pet */}
-            <div style={{ flexShrink: 0 }}>
+            <div className="brain-pet">
               <PixelPet mood={mood} />
-              <div style={{ marginTop: 6, fontSize: 8, letterSpacing: '0.1em', color: '#555', textAlign: 'center' }}>
-                {mood.toUpperCase()}
-              </div>
             </div>
             {/* Status text + uptime */}
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 12, fontWeight: 700, color: '#f0f0f0', marginBottom: 3, letterSpacing: '0.04em' }}>
+            <div className="brain-info">
+              <div
+                className="brain-mood"
+                title={MOOD_TOOLTIP[mood]}
+              >
                 {MOOD_LABEL[mood]}
               </div>
-              <div style={{ fontSize: 9, color: '#555', letterSpacing: '0.06em', marginBottom: 12 }}>
+              <div className="brain-mood-sub">
                 {MOOD_SUBTEXT[mood]}
               </div>
-              <div style={{ fontSize: 9, color: '#444', letterSpacing: '0.12em', marginBottom: 2 }}>UPTIME</div>
-              <div style={{ fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums', letterSpacing: '0.02em', marginBottom: 10 }}>
-                {fmtUptime(uptime)}
-              </div>
-              <div style={{ fontSize: 9, color: '#333', letterSpacing: '0.1em' }}>
-                IDLE TIMEOUT {Math.floor(daemonStatus.idleTimeout / 60)}M
+              <div className="brain-stats">
+                <div>
+                  <div className="brain-stat-label" title="How long the controller process has been running">
+                    UPTIME
+                  </div>
+                  <div className="brain-stat-value">
+                    {fmtUptime(uptime)}
+                  </div>
+                </div>
+                <div>
+                  <div className="brain-stat-label" title="Idle runners are removed after this duration">
+                    IDLE TIMEOUT
+                  </div>
+                  <div className="brain-stat-value">
+                    {Math.floor(daemonStatus.idleTimeout / 60)}m
+                  </div>
+                </div>
               </div>
             </div>
           </div>
           {/* System vitals */}
-          <div className="brain-vitals" style={{ borderTop: '1px solid #1e1e1e', marginTop: 14, paddingTop: 14 }}>
-            <div className="label" style={{ marginBottom: 10 }}>SYSTEM VITALS</div>
+          <div className="brain-vitals">
+            <div className="label" style={{ marginBottom: 10 }}>HOST VITALS</div>
             <SystemVitals vitals={machineVitals} />
           </div>
         </div>
@@ -259,7 +261,7 @@ export default function App() {
 
         {/* Runner Sets */}
         <div className="cell">
-          <div className="label" style={{ marginBottom: 22 }}>RUNNER SETS</div>
+          <div className="label" style={{ marginBottom: 14 }}>RUNNER SETS</div>
           {runnerSets.map(rs => (
             <RunnerSetPanel key={rs.name} rs={rs} now={now} />
           ))}
@@ -267,8 +269,8 @@ export default function App() {
 
         {/* Recent Jobs */}
         <div className="cell">
-          <div className="label" style={{ marginBottom: 14 }}>RECENT JOBS</div>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 54px 58px', gap: 10, paddingBottom: 6, marginBottom: 4, borderBottom: '1px solid #242424', fontSize: 9, color: '#444', letterSpacing: '0.15em', textTransform: 'uppercase' }}>
+          <div className="label" style={{ marginBottom: 10 }}>RECENT JOBS</div>
+          <div className="job-row job-row-head">
             <span>Runner</span>
             <span>Result</span>
             <span style={{ textAlign: 'right' }}>Duration</span>

--- a/dashboard/src/components/JobRow.tsx
+++ b/dashboard/src/components/JobRow.tsx
@@ -1,5 +1,5 @@
 import type { JobRecord } from '../types'
-import { elapsed, fmtDuration, shortName } from '../utils'
+import { elapsed, fmtDuration } from '../utils'
 
 export function JobRow({ job, now }: { job: JobRecord; now: Date }) {
   const isRunning = job.result === 'running'
@@ -17,11 +17,12 @@ export function JobRow({ job, now }: { job: JobRecord; now: Date }) {
 
   return (
     <div className="job-row" style={{ opacity: isRunning ? 1 : 0.7 }}>
-      <span style={{
-        color: isRunning ? '#f0f0f0' : '#888',
-        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-      }}>
-        {shortName(job.runnerName)}
+      <span
+        className="ellipsis"
+        title={job.runnerName}
+        style={{ color: isRunning ? '#f0f0f0' : '#888', minWidth: 0 }}
+      >
+        {job.runnerName}
       </span>
       {resultEl}
       <span style={{ color: '#666', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>

--- a/dashboard/src/components/RunnerSetPanel.tsx
+++ b/dashboard/src/components/RunnerSetPanel.tsx
@@ -1,5 +1,5 @@
 import type { Runner, RunnerSet } from '../types'
-import { elapsed, fmtDuration, shortName } from '../utils'
+import { elapsed, fmtDuration } from '../utils'
 
 function StateLabel({ state }: { state: Runner['state'] }) {
   const map: Record<Runner['state'], { label: string; color: string }> = {
@@ -20,8 +20,12 @@ function RunnerRow({ runner, now }: { runner: Runner; now: Date }) {
   const sec = elapsed(runner.since, now)
   return (
     <div className="runner-row">
-      <span style={{ color: '#bbb', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {shortName(runner.name)}
+      <span
+        className="ellipsis"
+        title={runner.name}
+        style={{ color: '#bbb', minWidth: 0 }}
+      >
+        {runner.name}
       </span>
       <StateLabel state={runner.state} />
       <span style={{ color: '#888', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
@@ -40,31 +44,32 @@ export function RunnerSetPanel({ rs, now }: { rs: RunnerSet; now: Date }) {
   const unknownCount = rs.runners.filter(r => r.state === 'unknown').length
 
   return (
-    <div style={{ marginBottom: 28 }}>
+    <div className="runner-set">
       {/* Set header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
-        <span style={{ fontWeight: 700, fontSize: 13, letterSpacing: '0.04em' }}>
+      <div className="runner-set-header">
+        <span
+          className="runner-set-name ellipsis"
+          title={rs.name}
+        >
           {rs.name}
         </span>
-        <span style={{ color: '#666', fontSize: 10, letterSpacing: '0.12em' }}>
+        <span className="runner-set-meta">
           {rs.backend.toUpperCase()} · {count}/{rs.maxRunners}
         </span>
       </div>
 
       {/* Image */}
-      <div style={{ color: '#555', fontSize: 10, marginBottom: 10, letterSpacing: '0.04em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+      <div className="runner-set-image ellipsis" title={rs.image}>
         {rs.image}
       </div>
 
       {/* Progress bar */}
-      <div style={{ marginBottom: 8 }}>
-        <div className="progress-track">
-          <div className="progress-fill" style={{ width: `${util * 100}%` }} />
-        </div>
+      <div className="progress-track" style={{ marginBottom: 8 }}>
+        <div className="progress-fill" style={{ width: `${util * 100}%` }} />
       </div>
 
       {/* State counts */}
-      <div style={{ display: 'flex', gap: 16, marginBottom: 12, fontSize: 10, letterSpacing: '0.12em' }}>
+      <div className="runner-set-states">
         {busyCount > 0 && <span style={{ color: '#f0f0f0' }}>{busyCount} BUSY</span>}
         {idleCount > 0 && <span style={{ color: '#888' }}>{idleCount} IDLE</span>}
         {prepCount > 0 && <span style={{ color: '#aaa' }}>{prepCount} PREP</span>}
@@ -72,19 +77,20 @@ export function RunnerSetPanel({ rs, now }: { rs: RunnerSet; now: Date }) {
         {count === 0 && <span style={{ color: '#444' }}>NO RUNNERS</span>}
       </div>
 
-      {/* Column headers */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 64px 64px', gap: 10, paddingBottom: 5, marginBottom: 4, borderBottom: '1px solid #242424', fontSize: 9, color: '#444', letterSpacing: '0.15em', textTransform: 'uppercase' }}>
-        <span>Runner</span>
-        <span>State</span>
-        <span style={{ textAlign: 'right' }}>Duration</span>
-      </div>
+      {count > 0 && (
+        <>
+          {/* Column headers */}
+          <div className="runner-row runner-row-head">
+            <span>Runner</span>
+            <span>State</span>
+            <span style={{ textAlign: 'right' }}>Duration</span>
+          </div>
 
-      {/* Runners */}
-      {rs.runners.map(r => (
-        <RunnerRow key={r.name} runner={r} now={now} />
-      ))}
-      {rs.runners.length === 0 && (
-        <div style={{ color: '#444', fontSize: 12, padding: '8px 0' }}>— no active runners —</div>
+          {/* Runners */}
+          {rs.runners.map(r => (
+            <RunnerRow key={r.name} runner={r} now={now} />
+          ))}
+        </>
       )}
     </div>
   )

--- a/dashboard/src/components/petMood.ts
+++ b/dashboard/src/components/petMood.ts
@@ -1,15 +1,22 @@
 export type PetMood = 'idle' | 'busy' | 'sleeping' | 'alert'
 
 export const MOOD_LABEL: Record<PetMood, string> = {
-  idle:     'STANDING BY',
-  busy:     'PROCESSING',
-  sleeping: 'RESTING',
-  alert:    'SPINNING UP',
+  idle:     'WAITING FOR JOBS',
+  busy:     'JOBS RUNNING',
+  sleeping: 'NO RUNNERS',
+  alert:    'SCALING UP',
 }
 
 export const MOOD_SUBTEXT: Record<PetMood, string> = {
-  idle:     'runners waiting for jobs',
-  busy:     'jobs in execution',
-  sleeping: 'all runners idle',
-  alert:    'preparing new runners',
+  idle:     'runners online, awaiting work',
+  busy:     'one or more runners executing jobs',
+  sleeping: 'all runner sets are empty',
+  alert:    'new runners are being prepared',
+}
+
+export const MOOD_TOOLTIP: Record<PetMood, string> = {
+  idle:     'At least one runner is online and idle, ready to pick up the next job.',
+  busy:     'At least one runner is currently executing a job.',
+  sleeping: 'No runners are active. The controller is watching for jobs.',
+  alert:    'New runners are being provisioned to absorb pending jobs.',
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -37,7 +37,7 @@ html, body, #root {
   background: var(--border);
   gap: 1px;
   border: 1px solid var(--border);
-  margin-bottom: -1px;
+  border-bottom: none;
 }
 
 .grid-stats {
@@ -46,7 +46,7 @@ html, body, #root {
   background: var(--border);
   gap: 1px;
   border: 1px solid var(--border);
-  margin-bottom: 19px;
+  margin-bottom: 1px;
 }
 
 .grid-main {
@@ -59,7 +59,12 @@ html, body, #root {
 
 .cell {
   background: var(--bg);
-  padding: 20px 22px;
+  padding: 18px 20px;
+  min-width: 0;
+}
+
+.grid-stats .cell {
+  padding: 14px 16px;
 }
 
 /* Tablet: ≤ 900px */
@@ -71,7 +76,11 @@ html, body, #root {
     grid-column: 1 / -1;
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 20px;
+    column-gap: 24px;
+    row-gap: 0;
+  }
+  .grid-top .cell-brain > .label {
+    grid-column: 1 / -1;
   }
   .grid-top .cell-brain .brain-vitals {
     border-top: none;
@@ -218,7 +227,7 @@ html, body, #root {
 /* Table rows */
 .runner-row {
   display: grid;
-  grid-template-columns: 1fr 64px 64px;
+  grid-template-columns: minmax(0, 1fr) 64px 64px;
   gap: 10px;
   align-items: center;
   padding: 7px 0;
@@ -230,9 +239,20 @@ html, body, #root {
   border-bottom: none;
 }
 
+.runner-row-head {
+  padding-bottom: 5px;
+  padding-top: 0;
+  margin-bottom: 2px;
+  border-bottom: 1px solid var(--border);
+  font-size: 9px;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
 .job-row {
   display: grid;
-  grid-template-columns: 1fr 54px 58px;
+  grid-template-columns: minmax(0, 1fr) 54px 58px;
   gap: 10px;
   align-items: center;
   padding: 7px 0;
@@ -242,6 +262,244 @@ html, body, #root {
 
 .job-row:last-child {
   border-bottom: none;
+}
+
+.job-row-head {
+  padding: 0 0 5px 0;
+  margin-bottom: 2px;
+  border-bottom: 1px solid var(--border);
+  font-size: 9px;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+/* Ellipsis utility */
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+/* Runner Set card */
+.runner-set {
+  margin-bottom: 22px;
+}
+
+.runner-set:last-child {
+  margin-bottom: 0;
+}
+
+.runner-set-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.runner-set-name {
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  min-width: 0;
+  flex: 1;
+}
+
+.runner-set-meta {
+  color: #666;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.runner-set-image {
+  color: #555;
+  font-size: 10px;
+  margin-bottom: 8px;
+  letter-spacing: 0.04em;
+}
+
+.runner-set-states {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-bottom: 10px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+}
+
+/* Status card */
+.status-hero {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.status-hero-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  margin-bottom: 3px;
+  color: var(--text);
+}
+
+.status-hero-sub {
+  font-size: 9px;
+  color: #555;
+  letter-spacing: 0.1em;
+}
+
+.status-meta {
+  border-top: 1px solid #1e1e1e;
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.status-meta-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.meta-label {
+  font-size: 9px;
+  color: var(--text-muted);
+  letter-spacing: 0.15em;
+  margin-bottom: 3px;
+}
+
+.meta-value {
+  font-size: 11px;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+}
+
+.meta-strong {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Capacity card */
+.capacity-sub {
+  font-size: 10px;
+  color: #555;
+  letter-spacing: 0.12em;
+  margin-bottom: 14px;
+}
+
+.capacity-section {
+  border-top: 1px solid #1e1e1e;
+  padding-top: 12px;
+  margin-top: 0;
+}
+
+.capacity-section.throughput {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.capacity-set {
+  margin-bottom: 8px;
+}
+
+.capacity-set:last-child {
+  margin-bottom: 0;
+}
+
+.capacity-set-head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 4px;
+  gap: 8px;
+}
+
+.capacity-set-bar {
+  height: 4px;
+  background: #1a1a1a;
+  overflow: hidden;
+}
+
+.capacity-set-fill {
+  height: 100%;
+  transition: width 0.6s ease;
+  background-image: repeating-linear-gradient(90deg, transparent 0px, transparent 3px, rgba(0,0,0,0.35) 3px, rgba(0,0,0,0.35) 4px);
+}
+
+/* Brain (controller) section */
+.cell-brain {
+  display: flex;
+  flex-direction: column;
+}
+
+.brain-pet-row {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.brain-pet {
+  flex-shrink: 0;
+}
+
+.brain-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.brain-mood {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 3px;
+  letter-spacing: 0.04em;
+  cursor: help;
+}
+
+.brain-mood-sub {
+  font-size: 9px;
+  color: #666;
+  letter-spacing: 0.06em;
+  margin-bottom: 12px;
+  line-height: 1.4;
+}
+
+.brain-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.brain-stat-label {
+  font-size: 9px;
+  color: var(--text-muted);
+  letter-spacing: 0.12em;
+  margin-bottom: 2px;
+  cursor: help;
+}
+
+.brain-stat-value {
+  font-size: 14px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--text);
+}
+
+.brain-vitals {
+  border-top: 1px solid #1e1e1e;
+  margin-top: 14px;
+  padding-top: 14px;
 }
 
 /* Scrollbar */

--- a/dashboard/src/utils.ts
+++ b/dashboard/src/utils.ts
@@ -19,11 +19,13 @@ export function fmtUptime(seconds: number): string {
   return `${String(h).padStart(2, '0')}h:${String(m).padStart(2, '0')}m:${String(s).padStart(2, '0')}s`
 }
 
-export function shortName(name: string): string {
+export function shortName(name: string, max = 32): string {
+  if (name.length <= max) return name
   const parts = name.split('-')
+  if (parts.length < 2) return `${name.slice(0, max - 1)}…`
   const suffix = parts[parts.length - 1]
   const prefix = parts.slice(0, -1).join('-')
-  const max = 20
-  const trimmed = prefix.length > max ? '...' + prefix.slice(-(max - 3)) : prefix
-  return `${trimmed}-${suffix}`
+  const room = max - suffix.length - 2
+  if (room <= 0) return `…${suffix}`
+  return `${prefix.slice(0, room)}…${suffix}`
 }


### PR DESCRIPTION
## Summary

Coordinated visual / layout fixes for the dashboard. All five issues touch the same overview + runner-set + controller area, so they are addressed in one consistent pass.

- **Name truncation** (#56, #59): Runner and runner-set names now use right-side CSS ellipsis (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`) inside grid cells with `minmax(0, 1fr)`, with a `title` attribute exposing the full name on hover. The legacy `shortName` helper that prepended `…` to the front of the name is no longer used by the rows; the function itself is kept (and corrected) so any future caller gets right-side truncation.
- **Layout balance** (#57, #60):
  - Shared `meta-label`, `meta-value`, `meta-strong` classes replace dozens of inline label styles, so STATUS / CAPACITY / CONTROLLER align vertically.
  - Tightened cell padding (`18px 20px`, stats cells `14px 16px`), reduced status hero / per-set / brain spacing, and removed the negative `margin-bottom: -1px` that visually disconnected the stats row from the cards above it.
  - Runner-set cards now use a `runner-set-*` class set; the column headers and "no active runners" filler text are hidden in the empty state, leaving the `NO RUNNERS` chip alone.
- **RUNNER BRAIN clarity** (#67): renamed the section to **CONTROLLER**. Mood labels were rephrased into something users can act on (`WAITING FOR JOBS`, `SCALING UP`, `JOBS RUNNING`, `NO RUNNERS`) and now carry tooltips. `UPTIME` and `IDLE TIMEOUT` keep the controller-process meaning explicit via tooltips. The vitals subsection is now `HOST VITALS` to make ownership obvious.

## Changes
- `dashboard/src/App.tsx` — restructured STATUS, CAPACITY, CONTROLLER cells onto shared classes; renamed RUNNER BRAIN -> CONTROLLER; added tooltips.
- `dashboard/src/components/RunnerSetPanel.tsx` — new `runner-set-*` classes; ellipsis + tooltip on name and image; hide runner table when empty.
- `dashboard/src/components/JobRow.tsx`, `dashboard/src/components/petMood.ts` — show full runner names with `title`; clearer mood labels and a new `MOOD_TOOLTIP` map.
- `dashboard/src/index.css` — new utility classes (`ellipsis`, `runner-set-*`, `status-*`, `capacity-*`, `brain-*`); replaced inline grid columns with `minmax(0, 1fr)` so ellipsis works inside grid rows.
- `dashboard/src/utils.ts` — fixed `shortName` so it truncates from the right with a trailing ellipsis (was prepending `...`).

## Test plan
- [x] `cd dashboard && pnpm install && pnpm build` — clean build, 0 TS errors
- [x] `pnpm lint` — 0 issues
- [x] `make build` — Go binary embeds the rebuilt dashboard
- [x] `make check` — fmt-check, vet, build, golangci-lint, prek hooks, unit tests all green
- [ ] Manual visual check: long runner names show ellipsis at the end with full name on hover; STATUS / CAPACITY / CONTROLLER feel balanced; CONTROLLER tooltips explain each field; empty runner-sets are tight (no orphan column header)

Fixes #56
Fixes #57
Fixes #59
Fixes #60
Fixes #67