### PR TITLE
feat(console): add job logs and resource history

### DIFF
--- a/cmd/elastic-fruit-runner/main.go
+++ b/cmd/elastic-fruit-runner/main.go
@@ -66,13 +66,14 @@ func runDaemon() error {
 	}()
 
 	vitalsService := vitals.New(startedAt)
-	go vitalsService.Start(ctx, 5*time.Second)
 
 	managementService, err := management.New(cfg)
 	if err != nil {
 		return fmt.Errorf("initialize scale set controller management service: %w", err)
 	}
 	defer managementService.Close()
+	vitalsService.SetOnUpdate(managementService.RecordHostVitals)
+	go vitalsService.Start(ctx, 5*time.Second)
 	managementService.Start(ctx)
 
 	databasePath, err := cfg.DatabasePath()

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -2,6 +2,12 @@ import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import useSWR from 'swr'
 import { fetchSession, login, logout, setupAdmin } from './api/fetchers'
+import {
+  fetchHostResources,
+  fetchJobLogs,
+  fetchJobResources,
+  fetchJobs,
+} from './api/fetchers'
 import { useDashboardSync } from './hooks/useDashboardSync'
 import { useDashboardStore } from './store/useDashboardStore'
 import type {
@@ -9,6 +15,7 @@ import type {
   JobRecord,
   MachineVitals,
   RunnerSet,
+  ResourceSample,
   SessionState,
 } from './types'
 
@@ -232,19 +239,42 @@ function Overview() {
   )
 }
 
-function JobsPage({ jobs, now }: { jobs: JobRecord[]; now: Date }) {
+function JobsPage({ jobs: initialJobs, now }: { jobs: JobRecord[]; now: Date }) {
+  const [status, setStatus] = useState('')
+  const [repository, setRepository] = useState('')
+  const [workflow, setWorkflow] = useState('')
+  const [selected, setSelected] = useState<JobRecord | null>(null)
+  const jobs = useSWR(
+    ['jobs', status, repository, workflow],
+    () => fetchJobs({ status, repository, workflow, pageSize: 100 }),
+    { refreshInterval: 5000, fallbackData: { jobs: initialJobs, nextCursor: '' } },
+  )
   return (
     <>
       <PageHeader title="Jobs" detail="Recent job history from local storage." />
-      <section className="panel">
-        <PanelHeader title="Job records" detail={`${jobs.length} records`} />
-        <JobTable jobs={jobs} now={now} />
+      <section className="filter-bar">
+        <select aria-label="Job status" value={status} onChange={event => setStatus(event.target.value)}>
+          <option value="">All results</option>
+          <option value="running">Running</option>
+          <option value="succeeded">Success</option>
+          <option value="failed">Failure</option>
+          <option value="canceled">Canceled</option>
+        </select>
+        <input aria-label="Repository filter" placeholder="Repository" value={repository} onChange={event => setRepository(event.target.value)} />
+        <input aria-label="Workflow filter" placeholder="Workflow" value={workflow} onChange={event => setWorkflow(event.target.value)} />
       </section>
+      <section className="panel">
+        <PanelHeader title="Job records" detail={`${jobs.data?.jobs.length ?? 0} records`} />
+        {jobs.error
+          ? <EmptyState title="Job history unavailable" detail={String(jobs.error)} />
+          : <JobTable jobs={jobs.data?.jobs ?? []} now={now} onSelect={setSelected} />}
+      </section>
+      {selected && <JobDetail job={selected} onClose={() => setSelected(null)} />}
     </>
   )
 }
 
-function JobTable({ jobs, now }: { jobs: JobRecord[]; now: Date }) {
+function JobTable({ jobs, now, onSelect }: { jobs: JobRecord[]; now: Date; onSelect?: (job: JobRecord) => void }) {
   if (jobs.length === 0) return <EmptyState title="No jobs recorded" detail="Jobs appear after a runner accepts work." />
   return (
     <div className="table-wrap">
@@ -252,6 +282,7 @@ function JobTable({ jobs, now }: { jobs: JobRecord[]; now: Date }) {
         <thead>
           <tr>
             <th>Job</th>
+            <th>Repository</th>
             <th>Runner set</th>
             <th>Runner</th>
             <th>Result</th>
@@ -261,8 +292,9 @@ function JobTable({ jobs, now }: { jobs: JobRecord[]; now: Date }) {
         </thead>
         <tbody>
           {jobs.map(job => (
-            <tr key={`${job.id}-${job.startedAt.toISOString()}`}>
-              <td className="mono">{job.id}</td>
+            <tr className={onSelect ? 'clickable-row' : ''} key={`${job.id}-${job.startedAt.toISOString()}`} onClick={() => onSelect?.(job)}>
+              <td className="mono">{job.displayName || job.id}</td>
+              <td>{job.owner && job.repository ? `${job.owner}/${job.repository}` : 'Unknown'}</td>
               <td>{job.runnerSetName || 'Unknown'}</td>
               <td>{job.runnerName || 'Unknown'}</td>
               <td><ResultBadge result={job.result} /></td>
@@ -272,6 +304,47 @@ function JobTable({ jobs, now }: { jobs: JobRecord[]; now: Date }) {
           ))}
         </tbody>
       </table>
+    </div>
+  )
+}
+
+function JobDetail({ job, onClose }: { job: JobRecord; onClose: () => void }) {
+  const logs = useSWR(['jobLogs', job.id], () => fetchJobLogs(job.id), {
+    refreshInterval: job.result === 'running' ? 2000 : 0,
+  })
+  const resources = useSWR(['jobResources', job.id], () => fetchJobResources(job.id), {
+    refreshInterval: job.result === 'running' ? 5000 : 0,
+  })
+  const samples = resources.data ?? []
+  const estimate = samples.some(sample => sample.accuracy === 'estimate')
+  return (
+    <div className="detail-overlay" role="dialog" aria-modal="true" aria-label="Job detail">
+      <section className="detail-panel">
+        <div className="detail-title">
+          <div>
+            <span className="eyebrow">Job detail</span>
+            <h2>{job.displayName || job.id}</h2>
+          </div>
+          <button className="text-button" onClick={onClose}>Close</button>
+        </div>
+        <DefinitionList rows={[
+          ['Repository', job.owner && job.repository ? `${job.owner}/${job.repository}` : 'Unknown'],
+          ['Workflow', job.workflowRef || 'Unknown'],
+          ['Runner', job.runnerName],
+          ['Backend', job.backend || 'Unknown'],
+          ['Queued', job.queuedAt ? formatDate(job.queuedAt) : 'Unavailable'],
+          ['Runner assigned', job.runnerAssignedAt ? formatDate(job.runnerAssignedAt) : 'Unavailable'],
+          ['Started', formatDate(job.startedAt)],
+          ['Completed', job.completedAt ? formatDate(job.completedAt) : 'Running'],
+        ]} />
+        {job.actionsURL && <a className="external-link" href={job.actionsURL} target="_blank" rel="noreferrer">Open in GitHub Actions</a>}
+        <div className="panel-header"><h2>Resource history</h2><span>{estimate ? 'Tart host estimate' : 'Backend data'}</span></div>
+        {estimate && <div className="notice warning">Guest resource usage is unavailable. Tart values show VM allocation and host side estimates.</div>}
+        <ResourceChart samples={samples} field="cpuPercent" label="CPU" suffix="%" />
+        <ResourceChart samples={samples} field="memoryUsedBytes" label="Memory" format={formatBytes} />
+        <div className="panel-header"><h2>Runner log</h2><span>{logs.data?.lines.length ?? 0} chunks</span></div>
+        <pre className="job-log">{logs.data?.lines.map(line => line.text).join('') || 'No log data is available.'}</pre>
+      </section>
     </div>
   )
 }
@@ -367,6 +440,11 @@ function SystemPage() {
   const store = useDashboardStore()
   const system = store.systemInfo
   const daemon = store.daemonStatus
+  const history = useSWR(
+    'hostResources',
+    () => fetchHostResources(new Date(Date.now() - 60 * 60 * 1000), new Date()),
+    { refreshInterval: 5000 },
+  )
   return (
     <>
       <PageHeader title="System" detail="Daemon build, storage, and current host health." />
@@ -395,10 +473,44 @@ function SystemPage() {
         </section>
       </div>
       <section className="panel">
-        <PanelHeader title="Host resources" detail="Current sample" />
+        <PanelHeader title="Host resources" detail={history.data?.earliestAt ? `Available since ${formatDate(history.data.earliestAt)}` : 'Current sample'} />
         <Vitals vitals={store.machineVitals} />
+        <ResourceChart samples={history.data?.samples ?? []} field="cpuPercent" label="CPU history" suffix="%" />
+        <ResourceChart samples={history.data?.samples ?? []} field="memoryUsedBytes" label="Memory history" format={formatBytes} />
       </section>
     </>
+  )
+}
+
+function ResourceChart({
+  samples,
+  field,
+  label,
+  suffix = '',
+  format,
+}: {
+  samples: ResourceSample[]
+  field: 'cpuPercent' | 'memoryUsedBytes'
+  label: string
+  suffix?: string
+  format?: (value: number) => string
+}) {
+  if (samples.length < 2) return <EmptyState title={`${label} has no history yet`} />
+  const values = samples.map(sample => sample[field])
+  const maxValue = Math.max(...values, 1)
+  const points = values.map((value, index) => {
+    const x = values.length === 1 ? 0 : index / (values.length - 1) * 100
+    const y = 34 - value / maxValue * 30
+    return `${x},${y}`
+  }).join(' ')
+  const latest = values.at(-1) ?? 0
+  return (
+    <div className="resource-chart">
+      <div><span>{label}</span><strong>{format ? format(latest) : `${latest.toFixed(1)}${suffix}`}</strong></div>
+      <svg viewBox="0 0 100 36" preserveAspectRatio="none" role="img" aria-label={label}>
+        <polyline points={points} />
+      </svg>
+    </div>
   )
 }
 

--- a/dashboard/src/api/fetchers.ts
+++ b/dashboard/src/api/fetchers.ts
@@ -10,6 +10,8 @@ import type {
   Module,
   Runner,
   RunnerSet,
+  ResourceSample,
+  JobLog,
   SessionState,
   SystemInfo,
 } from '../types'
@@ -185,24 +187,142 @@ const JOB_RESULT_MAP: Record<string, JobRecord['result']> = {
 }
 
 export async function fetchRecentJobs(): Promise<JobRecord[]> {
+  const page = await fetchJobs({})
+  return page.jobs
+}
+
+interface JobResponse {
+  id: string
+  runnerName: string
+  runnerSetName: string
+  result: string
+  startedAt: string
+  completedAt?: string
+  owner?: string
+  repository?: string
+  workflowRef?: string
+  displayName?: string
+  workflowRunId?: number
+  eventName?: string
+  labels?: string[]
+  queuedAt?: string
+  scaleSetAssignedAt?: string
+  runnerAssignedAt?: string
+  backend?: string
+  actionsUrl?: string
+}
+
+export async function fetchJobs(filters: {
+  status?: string
+  runnerSet?: string
+  repository?: string
+  workflow?: string
+  cursor?: string
+  pageSize?: number
+}): Promise<{ jobs: JobRecord[]; nextCursor: string }> {
   const data = await rpc<{
-    jobRecords?: Array<{
-      id: string
-      runnerName: string
-      runnerSetName: string
-      result: string
-      startedAt: string
-      completedAt?: string
-    }>
-  }>('ListJobRecords')
-  return (data.jobRecords ?? []).map(job => ({
+    jobRecords?: JobResponse[]
+    nextCursor?: string
+  }>('ListJobRecords', filters)
+  return {
+    jobs: (data.jobRecords ?? []).map(toJob),
+    nextCursor: data.nextCursor ?? '',
+  }
+}
+
+export async function fetchJobDetail(id: string): Promise<JobRecord> {
+  const data = await rpc<{ job: JobResponse }>('GetJobDetail', { id })
+  return toJob(data.job)
+}
+
+export async function fetchJobLogs(jobId: string, afterSequence = 0): Promise<{ lines: JobLog[]; nextSequence: number }> {
+  const data = await rpc<{
+    lines?: Array<{ sequence: number; recordedAt: string; text: string }>
+    nextSequence?: number
+  }>('GetJobLogs', { jobId, afterSequence, pageSize: 500 })
+  return {
+    lines: (data.lines ?? []).map(line => ({
+      sequence: line.sequence,
+      recordedAt: new Date(line.recordedAt),
+      text: line.text,
+    })),
+    nextSequence: data.nextSequence ?? afterSequence,
+  }
+}
+
+export async function fetchJobResources(jobId: string): Promise<ResourceSample[]> {
+  const data = await rpc<{ samples?: ResourceSampleResponse[] }>('GetJobResourceSamples', { jobId })
+  return (data.samples ?? []).map(toResourceSample)
+}
+
+export async function fetchHostResources(from: Date, to: Date): Promise<{ samples: ResourceSample[]; earliestAt: Date | null }> {
+  const data = await rpc<{ samples?: ResourceSampleResponse[]; earliestAt?: string }>(
+    'GetHostResourceSamples',
+    { from: from.toISOString(), to: to.toISOString() },
+  )
+  return {
+    samples: (data.samples ?? []).map(toResourceSample),
+    earliestAt: data.earliestAt ? new Date(data.earliestAt) : null,
+  }
+}
+
+interface ResourceSampleResponse {
+  recordedAt: string
+  source?: string
+  accuracy?: string
+  cpuPercent?: number
+  memoryUsedBytes?: number
+  memoryAvailableBytes?: number
+  diskUsedBytes?: number
+  diskAvailableBytes?: number
+  diskReadBytes?: number
+  diskWriteBytes?: number
+  networkReceiveBytes?: number
+  networkSendBytes?: number
+  loadOne?: number
+  temperatureCelsius?: number
+}
+
+function toResourceSample(sample: ResourceSampleResponse): ResourceSample {
+  return {
+    recordedAt: new Date(sample.recordedAt),
+    source: sample.source ?? '',
+    accuracy: sample.accuracy === 'RESOURCE_ACCURACY_ESTIMATE' ? 'estimate' : 'exact',
+    cpuPercent: sample.cpuPercent ?? 0,
+    memoryUsedBytes: sample.memoryUsedBytes ?? 0,
+    memoryAvailableBytes: sample.memoryAvailableBytes ?? 0,
+    diskUsedBytes: sample.diskUsedBytes ?? 0,
+    diskAvailableBytes: sample.diskAvailableBytes ?? 0,
+    diskReadBytes: sample.diskReadBytes ?? 0,
+    diskWriteBytes: sample.diskWriteBytes ?? 0,
+    networkReceiveBytes: sample.networkReceiveBytes ?? 0,
+    networkSendBytes: sample.networkSendBytes ?? 0,
+    loadOne: sample.loadOne ?? 0,
+    temperatureCelsius: sample.temperatureCelsius ?? 0,
+  }
+}
+
+function toJob(job: JobResponse): JobRecord {
+  return {
     id: job.id,
     runnerName: job.runnerName,
     runnerSetName: job.runnerSetName,
     result: JOB_RESULT_MAP[job.result] ?? (job.completedAt ? 'failure' : 'running'),
     startedAt: new Date(job.startedAt),
     completedAt: job.completedAt ? new Date(job.completedAt) : null,
-  }))
+    owner: job.owner ?? '',
+    repository: job.repository ?? '',
+    workflowRef: job.workflowRef ?? '',
+    displayName: job.displayName ?? '',
+    workflowRunId: job.workflowRunId ?? 0,
+    eventName: job.eventName ?? '',
+    labels: job.labels ?? [],
+    queuedAt: job.queuedAt ? new Date(job.queuedAt) : null,
+    scaleSetAssignedAt: job.scaleSetAssignedAt ? new Date(job.scaleSetAssignedAt) : null,
+    runnerAssignedAt: job.runnerAssignedAt ? new Date(job.runnerAssignedAt) : null,
+    backend: BACKEND_MAP[job.backend ?? ''] ?? 'unknown',
+    actionsURL: job.actionsUrl ?? '',
+  }
 }
 
 export async function fetchMachineVitals(): Promise<MachineVitals> {

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -33,7 +33,8 @@ body,
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 
@@ -510,6 +511,107 @@ input:focus {
   border-color: var(--blue);
 }
 
+.filter-bar {
+  display: grid;
+  grid-template-columns: 180px minmax(180px, 1fr) minmax(180px, 1fr);
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.filter-bar input,
+.filter-bar select {
+  width: 100%;
+  margin: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text);
+  background: var(--panel);
+}
+
+.clickable-row {
+  cursor: pointer;
+}
+
+.clickable-row:hover {
+  background: var(--panel-raised);
+}
+
+.detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: flex-end;
+  background: rgb(0 0 0 / 55%);
+}
+
+.detail-panel {
+  width: min(720px, 100%);
+  height: 100%;
+  padding: 28px;
+  overflow-y: auto;
+  border-left: 1px solid var(--border-bright);
+  background: var(--bg);
+}
+
+.detail-title {
+  margin-bottom: 22px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.detail-title h2 {
+  margin: 4px 0 0;
+  font-size: 20px;
+}
+
+.eyebrow {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.external-link {
+  display: inline-block;
+  margin: 16px 0 24px;
+  color: var(--blue);
+  font-size: 12px;
+}
+
+.job-log {
+  max-height: 360px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
+.resource-chart {
+  margin: 12px 0 20px;
+}
+
+.resource-chart > div {
+  display: flex;
+  justify-content: space-between;
+  color: var(--dim);
+  font-size: 11px;
+}
+
+.resource-chart svg {
+  width: 100%;
+  height: 90px;
+  margin-top: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.resource-chart polyline {
+  fill: none;
+  stroke: var(--blue);
+  stroke-width: 1.2;
+  vector-effect: non-scaling-stroke;
+}
+
 .empty-state,
 .full-page-message {
   color: var(--dim);
@@ -574,6 +676,10 @@ input:focus {
 
   .content {
     padding: 24px 16px 48px;
+  }
+
+  .filter-bar {
+    grid-template-columns: 1fr;
   }
 
   .two-column,

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -33,6 +33,41 @@ export interface JobRecord {
   result: JobResult
   startedAt: Date
   completedAt: Date | null
+  owner?: string
+  repository?: string
+  workflowRef?: string
+  displayName?: string
+  workflowRunId?: number
+  eventName?: string
+  labels?: string[]
+  queuedAt?: Date | null
+  scaleSetAssignedAt?: Date | null
+  runnerAssignedAt?: Date | null
+  backend?: Backend
+  actionsURL?: string
+}
+
+export interface JobLog {
+  sequence: number
+  recordedAt: Date
+  text: string
+}
+
+export interface ResourceSample {
+  recordedAt: Date
+  source: string
+  accuracy: 'exact' | 'estimate'
+  cpuPercent: number
+  memoryUsedBytes: number
+  memoryAvailableBytes: number
+  diskUsedBytes: number
+  diskAvailableBytes: number
+  diskReadBytes: number
+  diskWriteBytes: number
+  networkReceiveBytes: number
+  networkSendBytes: number
+  loadOne: number
+  temperatureCelsius: number
 }
 
 export interface DaemonStatus {

--- a/gen/controlplane/v1/controlplane.pb.go
+++ b/gen/controlplane/v1/controlplane.pb.go
@@ -179,6 +179,55 @@ func (JobResult) EnumDescriptor() ([]byte, []int) {
 	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{2}
 }
 
+type ResourceAccuracy int32
+
+const (
+	ResourceAccuracy_RESOURCE_ACCURACY_UNSPECIFIED ResourceAccuracy = 0
+	ResourceAccuracy_RESOURCE_ACCURACY_EXACT       ResourceAccuracy = 1
+	ResourceAccuracy_RESOURCE_ACCURACY_ESTIMATE    ResourceAccuracy = 2
+)
+
+// Enum value maps for ResourceAccuracy.
+var (
+	ResourceAccuracy_name = map[int32]string{
+		0: "RESOURCE_ACCURACY_UNSPECIFIED",
+		1: "RESOURCE_ACCURACY_EXACT",
+		2: "RESOURCE_ACCURACY_ESTIMATE",
+	}
+	ResourceAccuracy_value = map[string]int32{
+		"RESOURCE_ACCURACY_UNSPECIFIED": 0,
+		"RESOURCE_ACCURACY_EXACT":       1,
+		"RESOURCE_ACCURACY_ESTIMATE":    2,
+	}
+)
+
+func (x ResourceAccuracy) Enum() *ResourceAccuracy {
+	p := new(ResourceAccuracy)
+	*p = x
+	return p
+}
+
+func (x ResourceAccuracy) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ResourceAccuracy) Descriptor() protoreflect.EnumDescriptor {
+	return file_controlplane_v1_controlplane_proto_enumTypes[3].Descriptor()
+}
+
+func (ResourceAccuracy) Type() protoreflect.EnumType {
+	return &file_controlplane_v1_controlplane_proto_enumTypes[3]
+}
+
+func (x ResourceAccuracy) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ResourceAccuracy.Descriptor instead.
+func (ResourceAccuracy) EnumDescriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{3}
+}
+
 type ConfigSyncState int32
 
 const (
@@ -215,11 +264,11 @@ func (x ConfigSyncState) String() string {
 }
 
 func (ConfigSyncState) Descriptor() protoreflect.EnumDescriptor {
-	return file_controlplane_v1_controlplane_proto_enumTypes[3].Descriptor()
+	return file_controlplane_v1_controlplane_proto_enumTypes[4].Descriptor()
 }
 
 func (ConfigSyncState) Type() protoreflect.EnumType {
-	return &file_controlplane_v1_controlplane_proto_enumTypes[3]
+	return &file_controlplane_v1_controlplane_proto_enumTypes[4]
 }
 
 func (x ConfigSyncState) Number() protoreflect.EnumNumber {
@@ -228,7 +277,7 @@ func (x ConfigSyncState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ConfigSyncState.Descriptor instead.
 func (ConfigSyncState) EnumDescriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{3}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{4}
 }
 
 type GetSessionRequest struct {
@@ -1273,6 +1322,14 @@ func (x *Runner) GetSince() *timestamppb.Timestamp {
 
 type ListJobRecordsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	RunnerSet     string                 `protobuf:"bytes,2,opt,name=runner_set,json=runnerSet,proto3" json:"runner_set,omitempty"`
+	Repository    string                 `protobuf:"bytes,3,opt,name=repository,proto3" json:"repository,omitempty"`
+	Workflow      string                 `protobuf:"bytes,4,opt,name=workflow,proto3" json:"workflow,omitempty"`
+	From          *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=from,proto3,oneof" json:"from,omitempty"`
+	To            *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=to,proto3,oneof" json:"to,omitempty"`
+	Cursor        string                 `protobuf:"bytes,7,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	PageSize      int32                  `protobuf:"varint,8,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1307,9 +1364,66 @@ func (*ListJobRecordsRequest) Descriptor() ([]byte, []int) {
 	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{19}
 }
 
+func (x *ListJobRecordsRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListJobRecordsRequest) GetRunnerSet() string {
+	if x != nil {
+		return x.RunnerSet
+	}
+	return ""
+}
+
+func (x *ListJobRecordsRequest) GetRepository() string {
+	if x != nil {
+		return x.Repository
+	}
+	return ""
+}
+
+func (x *ListJobRecordsRequest) GetWorkflow() string {
+	if x != nil {
+		return x.Workflow
+	}
+	return ""
+}
+
+func (x *ListJobRecordsRequest) GetFrom() *timestamppb.Timestamp {
+	if x != nil {
+		return x.From
+	}
+	return nil
+}
+
+func (x *ListJobRecordsRequest) GetTo() *timestamppb.Timestamp {
+	if x != nil {
+		return x.To
+	}
+	return nil
+}
+
+func (x *ListJobRecordsRequest) GetCursor() string {
+	if x != nil {
+		return x.Cursor
+	}
+	return ""
+}
+
+func (x *ListJobRecordsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
 type ListJobRecordsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	JobRecords    []*JobRecord           `protobuf:"bytes,1,rep,name=job_records,json=jobRecords,proto3" json:"job_records,omitempty"`
+	NextCursor    string                 `protobuf:"bytes,2,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1351,6 +1465,13 @@ func (x *ListJobRecordsResponse) GetJobRecords() []*JobRecord {
 	return nil
 }
 
+func (x *ListJobRecordsResponse) GetNextCursor() string {
+	if x != nil {
+		return x.NextCursor
+	}
+	return ""
+}
+
 type JobRecord struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique job identifier from GitHub.
@@ -1364,9 +1485,21 @@ type JobRecord struct {
 	// When the job started.
 	StartedAt *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
 	// When the job finished. Absent if still running.
-	CompletedAt   *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=completed_at,json=completedAt,proto3,oneof" json:"completed_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	CompletedAt        *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=completed_at,json=completedAt,proto3,oneof" json:"completed_at,omitempty"`
+	Owner              string                 `protobuf:"bytes,7,opt,name=owner,proto3" json:"owner,omitempty"`
+	Repository         string                 `protobuf:"bytes,8,opt,name=repository,proto3" json:"repository,omitempty"`
+	WorkflowRef        string                 `protobuf:"bytes,9,opt,name=workflow_ref,json=workflowRef,proto3" json:"workflow_ref,omitempty"`
+	DisplayName        string                 `protobuf:"bytes,10,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	WorkflowRunId      int64                  `protobuf:"varint,11,opt,name=workflow_run_id,json=workflowRunId,proto3" json:"workflow_run_id,omitempty"`
+	EventName          string                 `protobuf:"bytes,12,opt,name=event_name,json=eventName,proto3" json:"event_name,omitempty"`
+	Labels             []string               `protobuf:"bytes,13,rep,name=labels,proto3" json:"labels,omitempty"`
+	QueuedAt           *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=queued_at,json=queuedAt,proto3,oneof" json:"queued_at,omitempty"`
+	ScaleSetAssignedAt *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=scale_set_assigned_at,json=scaleSetAssignedAt,proto3,oneof" json:"scale_set_assigned_at,omitempty"`
+	RunnerAssignedAt   *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=runner_assigned_at,json=runnerAssignedAt,proto3,oneof" json:"runner_assigned_at,omitempty"`
+	Backend            Backend                `protobuf:"varint,17,opt,name=backend,proto3,enum=controlplane.v1.Backend" json:"backend,omitempty"`
+	ActionsUrl         string                 `protobuf:"bytes,18,opt,name=actions_url,json=actionsUrl,proto3" json:"actions_url,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *JobRecord) Reset() {
@@ -1441,6 +1574,690 @@ func (x *JobRecord) GetCompletedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *JobRecord) GetOwner() string {
+	if x != nil {
+		return x.Owner
+	}
+	return ""
+}
+
+func (x *JobRecord) GetRepository() string {
+	if x != nil {
+		return x.Repository
+	}
+	return ""
+}
+
+func (x *JobRecord) GetWorkflowRef() string {
+	if x != nil {
+		return x.WorkflowRef
+	}
+	return ""
+}
+
+func (x *JobRecord) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *JobRecord) GetWorkflowRunId() int64 {
+	if x != nil {
+		return x.WorkflowRunId
+	}
+	return 0
+}
+
+func (x *JobRecord) GetEventName() string {
+	if x != nil {
+		return x.EventName
+	}
+	return ""
+}
+
+func (x *JobRecord) GetLabels() []string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *JobRecord) GetQueuedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.QueuedAt
+	}
+	return nil
+}
+
+func (x *JobRecord) GetScaleSetAssignedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ScaleSetAssignedAt
+	}
+	return nil
+}
+
+func (x *JobRecord) GetRunnerAssignedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RunnerAssignedAt
+	}
+	return nil
+}
+
+func (x *JobRecord) GetBackend() Backend {
+	if x != nil {
+		return x.Backend
+	}
+	return Backend_BACKEND_UNSPECIFIED
+}
+
+func (x *JobRecord) GetActionsUrl() string {
+	if x != nil {
+		return x.ActionsUrl
+	}
+	return ""
+}
+
+type GetJobDetailRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetJobDetailRequest) Reset() {
+	*x = GetJobDetailRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetJobDetailRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetJobDetailRequest) ProtoMessage() {}
+
+func (x *GetJobDetailRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetJobDetailRequest.ProtoReflect.Descriptor instead.
+func (*GetJobDetailRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *GetJobDetailRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type GetJobDetailResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Job           *JobRecord             `protobuf:"bytes,1,opt,name=job,proto3" json:"job,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetJobDetailResponse) Reset() {
+	*x = GetJobDetailResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetJobDetailResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetJobDetailResponse) ProtoMessage() {}
+
+func (x *GetJobDetailResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetJobDetailResponse.ProtoReflect.Descriptor instead.
+func (*GetJobDetailResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *GetJobDetailResponse) GetJob() *JobRecord {
+	if x != nil {
+		return x.Job
+	}
+	return nil
+}
+
+type GetJobLogsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	JobId         string                 `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
+	AfterSequence int64                  `protobuf:"varint,2,opt,name=after_sequence,json=afterSequence,proto3" json:"after_sequence,omitempty"`
+	PageSize      int32                  `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetJobLogsRequest) Reset() {
+	*x = GetJobLogsRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetJobLogsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetJobLogsRequest) ProtoMessage() {}
+
+func (x *GetJobLogsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetJobLogsRequest.ProtoReflect.Descriptor instead.
+func (*GetJobLogsRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *GetJobLogsRequest) GetJobId() string {
+	if x != nil {
+		return x.JobId
+	}
+	return ""
+}
+
+func (x *GetJobLogsRequest) GetAfterSequence() int64 {
+	if x != nil {
+		return x.AfterSequence
+	}
+	return 0
+}
+
+func (x *GetJobLogsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+type JobLogLine struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sequence      int64                  `protobuf:"varint,1,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	RecordedAt    *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=recorded_at,json=recordedAt,proto3" json:"recorded_at,omitempty"`
+	Text          string                 `protobuf:"bytes,3,opt,name=text,proto3" json:"text,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *JobLogLine) Reset() {
+	*x = JobLogLine{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JobLogLine) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JobLogLine) ProtoMessage() {}
+
+func (x *JobLogLine) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use JobLogLine.ProtoReflect.Descriptor instead.
+func (*JobLogLine) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *JobLogLine) GetSequence() int64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *JobLogLine) GetRecordedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RecordedAt
+	}
+	return nil
+}
+
+func (x *JobLogLine) GetText() string {
+	if x != nil {
+		return x.Text
+	}
+	return ""
+}
+
+type GetJobLogsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Lines         []*JobLogLine          `protobuf:"bytes,1,rep,name=lines,proto3" json:"lines,omitempty"`
+	NextSequence  int64                  `protobuf:"varint,2,opt,name=next_sequence,json=nextSequence,proto3" json:"next_sequence,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetJobLogsResponse) Reset() {
+	*x = GetJobLogsResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetJobLogsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetJobLogsResponse) ProtoMessage() {}
+
+func (x *GetJobLogsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetJobLogsResponse.ProtoReflect.Descriptor instead.
+func (*GetJobLogsResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *GetJobLogsResponse) GetLines() []*JobLogLine {
+	if x != nil {
+		return x.Lines
+	}
+	return nil
+}
+
+func (x *GetJobLogsResponse) GetNextSequence() int64 {
+	if x != nil {
+		return x.NextSequence
+	}
+	return 0
+}
+
+type ResourceSample struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	RecordedAt           *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=recorded_at,json=recordedAt,proto3" json:"recorded_at,omitempty"`
+	Source               string                 `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	Accuracy             ResourceAccuracy       `protobuf:"varint,3,opt,name=accuracy,proto3,enum=controlplane.v1.ResourceAccuracy" json:"accuracy,omitempty"`
+	CpuPercent           float64                `protobuf:"fixed64,4,opt,name=cpu_percent,json=cpuPercent,proto3" json:"cpu_percent,omitempty"`
+	MemoryUsedBytes      int64                  `protobuf:"varint,5,opt,name=memory_used_bytes,json=memoryUsedBytes,proto3" json:"memory_used_bytes,omitempty"`
+	MemoryAvailableBytes int64                  `protobuf:"varint,6,opt,name=memory_available_bytes,json=memoryAvailableBytes,proto3" json:"memory_available_bytes,omitempty"`
+	DiskUsedBytes        int64                  `protobuf:"varint,7,opt,name=disk_used_bytes,json=diskUsedBytes,proto3" json:"disk_used_bytes,omitempty"`
+	DiskAvailableBytes   int64                  `protobuf:"varint,8,opt,name=disk_available_bytes,json=diskAvailableBytes,proto3" json:"disk_available_bytes,omitempty"`
+	DiskReadBytes        int64                  `protobuf:"varint,9,opt,name=disk_read_bytes,json=diskReadBytes,proto3" json:"disk_read_bytes,omitempty"`
+	DiskWriteBytes       int64                  `protobuf:"varint,10,opt,name=disk_write_bytes,json=diskWriteBytes,proto3" json:"disk_write_bytes,omitempty"`
+	NetworkReceiveBytes  int64                  `protobuf:"varint,11,opt,name=network_receive_bytes,json=networkReceiveBytes,proto3" json:"network_receive_bytes,omitempty"`
+	NetworkSendBytes     int64                  `protobuf:"varint,12,opt,name=network_send_bytes,json=networkSendBytes,proto3" json:"network_send_bytes,omitempty"`
+	LoadOne              float64                `protobuf:"fixed64,13,opt,name=load_one,json=loadOne,proto3" json:"load_one,omitempty"`
+	TemperatureCelsius   float64                `protobuf:"fixed64,14,opt,name=temperature_celsius,json=temperatureCelsius,proto3" json:"temperature_celsius,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ResourceSample) Reset() {
+	*x = ResourceSample{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResourceSample) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResourceSample) ProtoMessage() {}
+
+func (x *ResourceSample) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResourceSample.ProtoReflect.Descriptor instead.
+func (*ResourceSample) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *ResourceSample) GetRecordedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RecordedAt
+	}
+	return nil
+}
+
+func (x *ResourceSample) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *ResourceSample) GetAccuracy() ResourceAccuracy {
+	if x != nil {
+		return x.Accuracy
+	}
+	return ResourceAccuracy_RESOURCE_ACCURACY_UNSPECIFIED
+}
+
+func (x *ResourceSample) GetCpuPercent() float64 {
+	if x != nil {
+		return x.CpuPercent
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetMemoryUsedBytes() int64 {
+	if x != nil {
+		return x.MemoryUsedBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetMemoryAvailableBytes() int64 {
+	if x != nil {
+		return x.MemoryAvailableBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetDiskUsedBytes() int64 {
+	if x != nil {
+		return x.DiskUsedBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetDiskAvailableBytes() int64 {
+	if x != nil {
+		return x.DiskAvailableBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetDiskReadBytes() int64 {
+	if x != nil {
+		return x.DiskReadBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetDiskWriteBytes() int64 {
+	if x != nil {
+		return x.DiskWriteBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetNetworkReceiveBytes() int64 {
+	if x != nil {
+		return x.NetworkReceiveBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetNetworkSendBytes() int64 {
+	if x != nil {
+		return x.NetworkSendBytes
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetLoadOne() float64 {
+	if x != nil {
+		return x.LoadOne
+	}
+	return 0
+}
+
+func (x *ResourceSample) GetTemperatureCelsius() float64 {
+	if x != nil {
+		return x.TemperatureCelsius
+	}
+	return 0
+}
+
+type GetJobResourceSamplesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	JobId         string                 `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetJobResourceSamplesRequest) Reset() {
+	*x = GetJobResourceSamplesRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetJobResourceSamplesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetJobResourceSamplesRequest) ProtoMessage() {}
+
+func (x *GetJobResourceSamplesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetJobResourceSamplesRequest.ProtoReflect.Descriptor instead.
+func (*GetJobResourceSamplesRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *GetJobResourceSamplesRequest) GetJobId() string {
+	if x != nil {
+		return x.JobId
+	}
+	return ""
+}
+
+type GetJobResourceSamplesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Samples       []*ResourceSample      `protobuf:"bytes,1,rep,name=samples,proto3" json:"samples,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetJobResourceSamplesResponse) Reset() {
+	*x = GetJobResourceSamplesResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetJobResourceSamplesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetJobResourceSamplesResponse) ProtoMessage() {}
+
+func (x *GetJobResourceSamplesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetJobResourceSamplesResponse.ProtoReflect.Descriptor instead.
+func (*GetJobResourceSamplesResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *GetJobResourceSamplesResponse) GetSamples() []*ResourceSample {
+	if x != nil {
+		return x.Samples
+	}
+	return nil
+}
+
+type GetHostResourceSamplesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	From          *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=from,proto3,oneof" json:"from,omitempty"`
+	To            *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=to,proto3,oneof" json:"to,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetHostResourceSamplesRequest) Reset() {
+	*x = GetHostResourceSamplesRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetHostResourceSamplesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetHostResourceSamplesRequest) ProtoMessage() {}
+
+func (x *GetHostResourceSamplesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetHostResourceSamplesRequest.ProtoReflect.Descriptor instead.
+func (*GetHostResourceSamplesRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *GetHostResourceSamplesRequest) GetFrom() *timestamppb.Timestamp {
+	if x != nil {
+		return x.From
+	}
+	return nil
+}
+
+func (x *GetHostResourceSamplesRequest) GetTo() *timestamppb.Timestamp {
+	if x != nil {
+		return x.To
+	}
+	return nil
+}
+
+type GetHostResourceSamplesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Samples       []*ResourceSample      `protobuf:"bytes,1,rep,name=samples,proto3" json:"samples,omitempty"`
+	EarliestAt    *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=earliest_at,json=earliestAt,proto3,oneof" json:"earliest_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetHostResourceSamplesResponse) Reset() {
+	*x = GetHostResourceSamplesResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetHostResourceSamplesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetHostResourceSamplesResponse) ProtoMessage() {}
+
+func (x *GetHostResourceSamplesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetHostResourceSamplesResponse.ProtoReflect.Descriptor instead.
+func (*GetHostResourceSamplesResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *GetHostResourceSamplesResponse) GetSamples() []*ResourceSample {
+	if x != nil {
+		return x.Samples
+	}
+	return nil
+}
+
+func (x *GetHostResourceSamplesResponse) GetEarliestAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.EarliestAt
+	}
+	return nil
+}
+
 type GetMachineVitalsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -1449,7 +2266,7 @@ type GetMachineVitalsRequest struct {
 
 func (x *GetMachineVitalsRequest) Reset() {
 	*x = GetMachineVitalsRequest{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[22]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1461,7 +2278,7 @@ func (x *GetMachineVitalsRequest) String() string {
 func (*GetMachineVitalsRequest) ProtoMessage() {}
 
 func (x *GetMachineVitalsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[22]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1474,7 +2291,7 @@ func (x *GetMachineVitalsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMachineVitalsRequest.ProtoReflect.Descriptor instead.
 func (*GetMachineVitalsRequest) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{22}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{32}
 }
 
 type GetMachineVitalsResponse struct {
@@ -1493,7 +2310,7 @@ type GetMachineVitalsResponse struct {
 
 func (x *GetMachineVitalsResponse) Reset() {
 	*x = GetMachineVitalsResponse{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[23]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1505,7 +2322,7 @@ func (x *GetMachineVitalsResponse) String() string {
 func (*GetMachineVitalsResponse) ProtoMessage() {}
 
 func (x *GetMachineVitalsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[23]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1518,7 +2335,7 @@ func (x *GetMachineVitalsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMachineVitalsResponse.ProtoReflect.Descriptor instead.
 func (*GetMachineVitalsResponse) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{23}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetMachineVitalsResponse) GetCpuUsagePercent() float32 {
@@ -1557,7 +2374,7 @@ type GetConfigStatusRequest struct {
 
 func (x *GetConfigStatusRequest) Reset() {
 	*x = GetConfigStatusRequest{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[24]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1569,7 +2386,7 @@ func (x *GetConfigStatusRequest) String() string {
 func (*GetConfigStatusRequest) ProtoMessage() {}
 
 func (x *GetConfigStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[24]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1582,7 +2399,7 @@ func (x *GetConfigStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetConfigStatusRequest) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{24}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{34}
 }
 
 type GetConfigStatusResponse struct {
@@ -1602,7 +2419,7 @@ type GetConfigStatusResponse struct {
 
 func (x *GetConfigStatusResponse) Reset() {
 	*x = GetConfigStatusResponse{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[25]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1614,7 +2431,7 @@ func (x *GetConfigStatusResponse) String() string {
 func (*GetConfigStatusResponse) ProtoMessage() {}
 
 func (x *GetConfigStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[25]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1627,7 +2444,7 @@ func (x *GetConfigStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetConfigStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetConfigStatusResponse) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{25}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetConfigStatusResponse) GetPath() string {
@@ -1701,7 +2518,7 @@ type GetSystemInfoRequest struct {
 
 func (x *GetSystemInfoRequest) Reset() {
 	*x = GetSystemInfoRequest{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[26]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1713,7 +2530,7 @@ func (x *GetSystemInfoRequest) String() string {
 func (*GetSystemInfoRequest) ProtoMessage() {}
 
 func (x *GetSystemInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[26]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1726,7 +2543,7 @@ func (x *GetSystemInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetSystemInfoRequest) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{26}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{36}
 }
 
 type GetSystemInfoResponse struct {
@@ -1742,7 +2559,7 @@ type GetSystemInfoResponse struct {
 
 func (x *GetSystemInfoResponse) Reset() {
 	*x = GetSystemInfoResponse{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[27]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1754,7 +2571,7 @@ func (x *GetSystemInfoResponse) String() string {
 func (*GetSystemInfoResponse) ProtoMessage() {}
 
 func (x *GetSystemInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[27]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1767,7 +2584,7 @@ func (x *GetSystemInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetSystemInfoResponse) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{27}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetSystemInfoResponse) GetOs() string {
@@ -1879,11 +2696,26 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x06Runner\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x122\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x1c.controlplane.v1.RunnerStateR\x05state\x120\n" +
-	"\x05since\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x05since\"\x17\n" +
-	"\x15ListJobRecordsRequest\"U\n" +
+	"\x05since\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x05since\"\xb5\x02\n" +
+	"\x15ListJobRecordsRequest\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"runner_set\x18\x02 \x01(\tR\trunnerSet\x12\x1e\n" +
+	"\n" +
+	"repository\x18\x03 \x01(\tR\n" +
+	"repository\x12\x1a\n" +
+	"\bworkflow\x18\x04 \x01(\tR\bworkflow\x123\n" +
+	"\x04from\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x04from\x88\x01\x01\x12/\n" +
+	"\x02to\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\x02to\x88\x01\x01\x12\x16\n" +
+	"\x06cursor\x18\a \x01(\tR\x06cursor\x12\x1b\n" +
+	"\tpage_size\x18\b \x01(\x05R\bpageSizeB\a\n" +
+	"\x05_fromB\x05\n" +
+	"\x03_to\"v\n" +
 	"\x16ListJobRecordsResponse\x12;\n" +
 	"\vjob_records\x18\x01 \x03(\v2\x1a.controlplane.v1.JobRecordR\n" +
-	"jobRecords\"\xa8\x02\n" +
+	"jobRecords\x12\x1f\n" +
+	"\vnext_cursor\x18\x02 \x01(\tR\n" +
+	"nextCursor\"\xf8\x06\n" +
 	"\tJobRecord\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vrunner_name\x18\x02 \x01(\tR\n" +
@@ -1892,8 +2724,78 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x06result\x18\x04 \x01(\x0e2\x1a.controlplane.v1.JobResultR\x06result\x129\n" +
 	"\n" +
 	"started_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12B\n" +
-	"\fcompleted_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\vcompletedAt\x88\x01\x01B\x0f\n" +
-	"\r_completed_at\"\x19\n" +
+	"\fcompleted_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\vcompletedAt\x88\x01\x01\x12\x14\n" +
+	"\x05owner\x18\a \x01(\tR\x05owner\x12\x1e\n" +
+	"\n" +
+	"repository\x18\b \x01(\tR\n" +
+	"repository\x12!\n" +
+	"\fworkflow_ref\x18\t \x01(\tR\vworkflowRef\x12!\n" +
+	"\fdisplay_name\x18\n" +
+	" \x01(\tR\vdisplayName\x12&\n" +
+	"\x0fworkflow_run_id\x18\v \x01(\x03R\rworkflowRunId\x12\x1d\n" +
+	"\n" +
+	"event_name\x18\f \x01(\tR\teventName\x12\x16\n" +
+	"\x06labels\x18\r \x03(\tR\x06labels\x12<\n" +
+	"\tqueued_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampH\x01R\bqueuedAt\x88\x01\x01\x12R\n" +
+	"\x15scale_set_assigned_at\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampH\x02R\x12scaleSetAssignedAt\x88\x01\x01\x12M\n" +
+	"\x12runner_assigned_at\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampH\x03R\x10runnerAssignedAt\x88\x01\x01\x122\n" +
+	"\abackend\x18\x11 \x01(\x0e2\x18.controlplane.v1.BackendR\abackend\x12\x1f\n" +
+	"\vactions_url\x18\x12 \x01(\tR\n" +
+	"actionsUrlB\x0f\n" +
+	"\r_completed_atB\f\n" +
+	"\n" +
+	"_queued_atB\x18\n" +
+	"\x16_scale_set_assigned_atB\x15\n" +
+	"\x13_runner_assigned_at\"%\n" +
+	"\x13GetJobDetailRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"D\n" +
+	"\x14GetJobDetailResponse\x12,\n" +
+	"\x03job\x18\x01 \x01(\v2\x1a.controlplane.v1.JobRecordR\x03job\"n\n" +
+	"\x11GetJobLogsRequest\x12\x15\n" +
+	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12%\n" +
+	"\x0eafter_sequence\x18\x02 \x01(\x03R\rafterSequence\x12\x1b\n" +
+	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\"y\n" +
+	"\n" +
+	"JobLogLine\x12\x1a\n" +
+	"\bsequence\x18\x01 \x01(\x03R\bsequence\x12;\n" +
+	"\vrecorded_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"recordedAt\x12\x12\n" +
+	"\x04text\x18\x03 \x01(\tR\x04text\"l\n" +
+	"\x12GetJobLogsResponse\x121\n" +
+	"\x05lines\x18\x01 \x03(\v2\x1b.controlplane.v1.JobLogLineR\x05lines\x12#\n" +
+	"\rnext_sequence\x18\x02 \x01(\x03R\fnextSequence\"\x81\x05\n" +
+	"\x0eResourceSample\x12;\n" +
+	"\vrecorded_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"recordedAt\x12\x16\n" +
+	"\x06source\x18\x02 \x01(\tR\x06source\x12=\n" +
+	"\baccuracy\x18\x03 \x01(\x0e2!.controlplane.v1.ResourceAccuracyR\baccuracy\x12\x1f\n" +
+	"\vcpu_percent\x18\x04 \x01(\x01R\n" +
+	"cpuPercent\x12*\n" +
+	"\x11memory_used_bytes\x18\x05 \x01(\x03R\x0fmemoryUsedBytes\x124\n" +
+	"\x16memory_available_bytes\x18\x06 \x01(\x03R\x14memoryAvailableBytes\x12&\n" +
+	"\x0fdisk_used_bytes\x18\a \x01(\x03R\rdiskUsedBytes\x120\n" +
+	"\x14disk_available_bytes\x18\b \x01(\x03R\x12diskAvailableBytes\x12&\n" +
+	"\x0fdisk_read_bytes\x18\t \x01(\x03R\rdiskReadBytes\x12(\n" +
+	"\x10disk_write_bytes\x18\n" +
+	" \x01(\x03R\x0ediskWriteBytes\x122\n" +
+	"\x15network_receive_bytes\x18\v \x01(\x03R\x13networkReceiveBytes\x12,\n" +
+	"\x12network_send_bytes\x18\f \x01(\x03R\x10networkSendBytes\x12\x19\n" +
+	"\bload_one\x18\r \x01(\x01R\aloadOne\x12/\n" +
+	"\x13temperature_celsius\x18\x0e \x01(\x01R\x12temperatureCelsius\"5\n" +
+	"\x1cGetJobResourceSamplesRequest\x12\x15\n" +
+	"\x06job_id\x18\x01 \x01(\tR\x05jobId\"Z\n" +
+	"\x1dGetJobResourceSamplesResponse\x129\n" +
+	"\asamples\x18\x01 \x03(\v2\x1f.controlplane.v1.ResourceSampleR\asamples\"\x95\x01\n" +
+	"\x1dGetHostResourceSamplesRequest\x123\n" +
+	"\x04from\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x04from\x88\x01\x01\x12/\n" +
+	"\x02to\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\x02to\x88\x01\x01B\a\n" +
+	"\x05_fromB\x05\n" +
+	"\x03_to\"\xad\x01\n" +
+	"\x1eGetHostResourceSamplesResponse\x129\n" +
+	"\asamples\x18\x01 \x03(\v2\x1f.controlplane.v1.ResourceSampleR\asamples\x12@\n" +
+	"\vearliest_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\n" +
+	"earliestAt\x88\x01\x01B\x0e\n" +
+	"\f_earliest_at\"\x19\n" +
 	"\x17GetMachineVitalsRequest\"\xd7\x01\n" +
 	"\x18GetMachineVitalsResponse\x12*\n" +
 	"\x11cpu_usage_percent\x18\x01 \x01(\x02R\x0fcpuUsagePercent\x120\n" +
@@ -1936,12 +2838,16 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x12JOB_RESULT_RUNNING\x10\x01\x12\x16\n" +
 	"\x12JOB_RESULT_SUCCESS\x10\x02\x12\x16\n" +
 	"\x12JOB_RESULT_FAILURE\x10\x03\x12\x17\n" +
-	"\x13JOB_RESULT_CANCELED\x10\x04*\x9f\x01\n" +
+	"\x13JOB_RESULT_CANCELED\x10\x04*r\n" +
+	"\x10ResourceAccuracy\x12!\n" +
+	"\x1dRESOURCE_ACCURACY_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17RESOURCE_ACCURACY_EXACT\x10\x01\x12\x1e\n" +
+	"\x1aRESOURCE_ACCURACY_ESTIMATE\x10\x02*\x9f\x01\n" +
 	"\x0fConfigSyncState\x12!\n" +
 	"\x1dCONFIG_SYNC_STATE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19CONFIG_SYNC_STATE_IN_SYNC\x10\x01\x12&\n" +
 	"\"CONFIG_SYNC_STATE_RESTART_REQUIRED\x10\x02\x12\"\n" +
-	"\x1eCONFIG_SYNC_STATE_DISK_INVALID\x10\x032\xa0\b\n" +
+	"\x1eCONFIG_SYNC_STATE_DISK_INVALID\x10\x032\xc7\v\n" +
 	"\x13ControlPlaneService\x12U\n" +
 	"\n" +
 	"GetSession\x12\".controlplane.v1.GetSessionRequest\x1a#.controlplane.v1.GetSessionResponse\x12U\n" +
@@ -1952,7 +2858,12 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x0eGetServiceInfo\x12&.controlplane.v1.GetServiceInfoRequest\x1a'.controlplane.v1.GetServiceInfoResponse\x12p\n" +
 	"\x13GetDashboardSummary\x12+.controlplane.v1.GetDashboardSummaryRequest\x1a,.controlplane.v1.GetDashboardSummaryResponse\x12a\n" +
 	"\x0eListRunnerSets\x12&.controlplane.v1.ListRunnerSetsRequest\x1a'.controlplane.v1.ListRunnerSetsResponse\x12a\n" +
-	"\x0eListJobRecords\x12&.controlplane.v1.ListJobRecordsRequest\x1a'.controlplane.v1.ListJobRecordsResponse\x12g\n" +
+	"\x0eListJobRecords\x12&.controlplane.v1.ListJobRecordsRequest\x1a'.controlplane.v1.ListJobRecordsResponse\x12[\n" +
+	"\fGetJobDetail\x12$.controlplane.v1.GetJobDetailRequest\x1a%.controlplane.v1.GetJobDetailResponse\x12U\n" +
+	"\n" +
+	"GetJobLogs\x12\".controlplane.v1.GetJobLogsRequest\x1a#.controlplane.v1.GetJobLogsResponse\x12v\n" +
+	"\x15GetJobResourceSamples\x12-.controlplane.v1.GetJobResourceSamplesRequest\x1a..controlplane.v1.GetJobResourceSamplesResponse\x12y\n" +
+	"\x16GetHostResourceSamples\x12..controlplane.v1.GetHostResourceSamplesRequest\x1a/.controlplane.v1.GetHostResourceSamplesResponse\x12g\n" +
 	"\x10GetMachineVitals\x12(.controlplane.v1.GetMachineVitalsRequest\x1a).controlplane.v1.GetMachineVitalsResponse\x12d\n" +
 	"\x0fGetConfigStatus\x12'.controlplane.v1.GetConfigStatusRequest\x1a(.controlplane.v1.GetConfigStatusResponse\x12^\n" +
 	"\rGetSystemInfo\x12%.controlplane.v1.GetSystemInfoRequest\x1a&.controlplane.v1.GetSystemInfoResponseBRZPgithub.com/boring-design/elastic-fruit-runner/gen/controlplane/v1;controlplanev1b\x06proto3"
@@ -1969,89 +2880,124 @@ func file_controlplane_v1_controlplane_proto_rawDescGZIP() []byte {
 	return file_controlplane_v1_controlplane_proto_rawDescData
 }
 
-var file_controlplane_v1_controlplane_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_controlplane_v1_controlplane_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_controlplane_v1_controlplane_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_controlplane_v1_controlplane_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_controlplane_v1_controlplane_proto_goTypes = []any{
-	(Backend)(0),                        // 0: controlplane.v1.Backend
-	(RunnerState)(0),                    // 1: controlplane.v1.RunnerState
-	(JobResult)(0),                      // 2: controlplane.v1.JobResult
-	(ConfigSyncState)(0),                // 3: controlplane.v1.ConfigSyncState
-	(*GetSessionRequest)(nil),           // 4: controlplane.v1.GetSessionRequest
-	(*GetSessionResponse)(nil),          // 5: controlplane.v1.GetSessionResponse
-	(*SetupAdminRequest)(nil),           // 6: controlplane.v1.SetupAdminRequest
-	(*SetupAdminResponse)(nil),          // 7: controlplane.v1.SetupAdminResponse
-	(*LoginRequest)(nil),                // 8: controlplane.v1.LoginRequest
-	(*LoginResponse)(nil),               // 9: controlplane.v1.LoginResponse
-	(*LogoutRequest)(nil),               // 10: controlplane.v1.LogoutRequest
-	(*LogoutResponse)(nil),              // 11: controlplane.v1.LogoutResponse
-	(*GetServiceInfoRequest)(nil),       // 12: controlplane.v1.GetServiceInfoRequest
-	(*GetServiceInfoResponse)(nil),      // 13: controlplane.v1.GetServiceInfoResponse
-	(*GetDashboardSummaryRequest)(nil),  // 14: controlplane.v1.GetDashboardSummaryRequest
-	(*GetDashboardSummaryResponse)(nil), // 15: controlplane.v1.GetDashboardSummaryResponse
-	(*BuildInfo)(nil),                   // 16: controlplane.v1.BuildInfo
-	(*Module)(nil),                      // 17: controlplane.v1.Module
-	(*BuildSetting)(nil),                // 18: controlplane.v1.BuildSetting
-	(*ListRunnerSetsRequest)(nil),       // 19: controlplane.v1.ListRunnerSetsRequest
-	(*ListRunnerSetsResponse)(nil),      // 20: controlplane.v1.ListRunnerSetsResponse
-	(*RunnerSet)(nil),                   // 21: controlplane.v1.RunnerSet
-	(*Runner)(nil),                      // 22: controlplane.v1.Runner
-	(*ListJobRecordsRequest)(nil),       // 23: controlplane.v1.ListJobRecordsRequest
-	(*ListJobRecordsResponse)(nil),      // 24: controlplane.v1.ListJobRecordsResponse
-	(*JobRecord)(nil),                   // 25: controlplane.v1.JobRecord
-	(*GetMachineVitalsRequest)(nil),     // 26: controlplane.v1.GetMachineVitalsRequest
-	(*GetMachineVitalsResponse)(nil),    // 27: controlplane.v1.GetMachineVitalsResponse
-	(*GetConfigStatusRequest)(nil),      // 28: controlplane.v1.GetConfigStatusRequest
-	(*GetConfigStatusResponse)(nil),     // 29: controlplane.v1.GetConfigStatusResponse
-	(*GetSystemInfoRequest)(nil),        // 30: controlplane.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil),       // 31: controlplane.v1.GetSystemInfoResponse
-	(*timestamppb.Timestamp)(nil),       // 32: google.protobuf.Timestamp
+	(Backend)(0),                           // 0: controlplane.v1.Backend
+	(RunnerState)(0),                       // 1: controlplane.v1.RunnerState
+	(JobResult)(0),                         // 2: controlplane.v1.JobResult
+	(ResourceAccuracy)(0),                  // 3: controlplane.v1.ResourceAccuracy
+	(ConfigSyncState)(0),                   // 4: controlplane.v1.ConfigSyncState
+	(*GetSessionRequest)(nil),              // 5: controlplane.v1.GetSessionRequest
+	(*GetSessionResponse)(nil),             // 6: controlplane.v1.GetSessionResponse
+	(*SetupAdminRequest)(nil),              // 7: controlplane.v1.SetupAdminRequest
+	(*SetupAdminResponse)(nil),             // 8: controlplane.v1.SetupAdminResponse
+	(*LoginRequest)(nil),                   // 9: controlplane.v1.LoginRequest
+	(*LoginResponse)(nil),                  // 10: controlplane.v1.LoginResponse
+	(*LogoutRequest)(nil),                  // 11: controlplane.v1.LogoutRequest
+	(*LogoutResponse)(nil),                 // 12: controlplane.v1.LogoutResponse
+	(*GetServiceInfoRequest)(nil),          // 13: controlplane.v1.GetServiceInfoRequest
+	(*GetServiceInfoResponse)(nil),         // 14: controlplane.v1.GetServiceInfoResponse
+	(*GetDashboardSummaryRequest)(nil),     // 15: controlplane.v1.GetDashboardSummaryRequest
+	(*GetDashboardSummaryResponse)(nil),    // 16: controlplane.v1.GetDashboardSummaryResponse
+	(*BuildInfo)(nil),                      // 17: controlplane.v1.BuildInfo
+	(*Module)(nil),                         // 18: controlplane.v1.Module
+	(*BuildSetting)(nil),                   // 19: controlplane.v1.BuildSetting
+	(*ListRunnerSetsRequest)(nil),          // 20: controlplane.v1.ListRunnerSetsRequest
+	(*ListRunnerSetsResponse)(nil),         // 21: controlplane.v1.ListRunnerSetsResponse
+	(*RunnerSet)(nil),                      // 22: controlplane.v1.RunnerSet
+	(*Runner)(nil),                         // 23: controlplane.v1.Runner
+	(*ListJobRecordsRequest)(nil),          // 24: controlplane.v1.ListJobRecordsRequest
+	(*ListJobRecordsResponse)(nil),         // 25: controlplane.v1.ListJobRecordsResponse
+	(*JobRecord)(nil),                      // 26: controlplane.v1.JobRecord
+	(*GetJobDetailRequest)(nil),            // 27: controlplane.v1.GetJobDetailRequest
+	(*GetJobDetailResponse)(nil),           // 28: controlplane.v1.GetJobDetailResponse
+	(*GetJobLogsRequest)(nil),              // 29: controlplane.v1.GetJobLogsRequest
+	(*JobLogLine)(nil),                     // 30: controlplane.v1.JobLogLine
+	(*GetJobLogsResponse)(nil),             // 31: controlplane.v1.GetJobLogsResponse
+	(*ResourceSample)(nil),                 // 32: controlplane.v1.ResourceSample
+	(*GetJobResourceSamplesRequest)(nil),   // 33: controlplane.v1.GetJobResourceSamplesRequest
+	(*GetJobResourceSamplesResponse)(nil),  // 34: controlplane.v1.GetJobResourceSamplesResponse
+	(*GetHostResourceSamplesRequest)(nil),  // 35: controlplane.v1.GetHostResourceSamplesRequest
+	(*GetHostResourceSamplesResponse)(nil), // 36: controlplane.v1.GetHostResourceSamplesResponse
+	(*GetMachineVitalsRequest)(nil),        // 37: controlplane.v1.GetMachineVitalsRequest
+	(*GetMachineVitalsResponse)(nil),       // 38: controlplane.v1.GetMachineVitalsResponse
+	(*GetConfigStatusRequest)(nil),         // 39: controlplane.v1.GetConfigStatusRequest
+	(*GetConfigStatusResponse)(nil),        // 40: controlplane.v1.GetConfigStatusResponse
+	(*GetSystemInfoRequest)(nil),           // 41: controlplane.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),          // 42: controlplane.v1.GetSystemInfoResponse
+	(*timestamppb.Timestamp)(nil),          // 43: google.protobuf.Timestamp
 }
 var file_controlplane_v1_controlplane_proto_depIdxs = []int32{
-	16, // 0: controlplane.v1.GetServiceInfoResponse.build_info:type_name -> controlplane.v1.BuildInfo
-	32, // 1: controlplane.v1.GetServiceInfoResponse.started_at:type_name -> google.protobuf.Timestamp
-	17, // 2: controlplane.v1.BuildInfo.main:type_name -> controlplane.v1.Module
-	17, // 3: controlplane.v1.BuildInfo.deps:type_name -> controlplane.v1.Module
-	18, // 4: controlplane.v1.BuildInfo.settings:type_name -> controlplane.v1.BuildSetting
-	17, // 5: controlplane.v1.Module.replace:type_name -> controlplane.v1.Module
-	21, // 6: controlplane.v1.ListRunnerSetsResponse.runner_sets:type_name -> controlplane.v1.RunnerSet
+	17, // 0: controlplane.v1.GetServiceInfoResponse.build_info:type_name -> controlplane.v1.BuildInfo
+	43, // 1: controlplane.v1.GetServiceInfoResponse.started_at:type_name -> google.protobuf.Timestamp
+	18, // 2: controlplane.v1.BuildInfo.main:type_name -> controlplane.v1.Module
+	18, // 3: controlplane.v1.BuildInfo.deps:type_name -> controlplane.v1.Module
+	19, // 4: controlplane.v1.BuildInfo.settings:type_name -> controlplane.v1.BuildSetting
+	18, // 5: controlplane.v1.Module.replace:type_name -> controlplane.v1.Module
+	22, // 6: controlplane.v1.ListRunnerSetsResponse.runner_sets:type_name -> controlplane.v1.RunnerSet
 	0,  // 7: controlplane.v1.RunnerSet.backend:type_name -> controlplane.v1.Backend
-	22, // 8: controlplane.v1.RunnerSet.runners:type_name -> controlplane.v1.Runner
+	23, // 8: controlplane.v1.RunnerSet.runners:type_name -> controlplane.v1.Runner
 	1,  // 9: controlplane.v1.Runner.state:type_name -> controlplane.v1.RunnerState
-	32, // 10: controlplane.v1.Runner.since:type_name -> google.protobuf.Timestamp
-	25, // 11: controlplane.v1.ListJobRecordsResponse.job_records:type_name -> controlplane.v1.JobRecord
-	2,  // 12: controlplane.v1.JobRecord.result:type_name -> controlplane.v1.JobResult
-	32, // 13: controlplane.v1.JobRecord.started_at:type_name -> google.protobuf.Timestamp
-	32, // 14: controlplane.v1.JobRecord.completed_at:type_name -> google.protobuf.Timestamp
-	3,  // 15: controlplane.v1.GetConfigStatusResponse.state:type_name -> controlplane.v1.ConfigSyncState
-	32, // 16: controlplane.v1.GetConfigStatusResponse.disk_modified_at:type_name -> google.protobuf.Timestamp
-	32, // 17: controlplane.v1.GetConfigStatusResponse.active_loaded_at:type_name -> google.protobuf.Timestamp
-	4,  // 18: controlplane.v1.ControlPlaneService.GetSession:input_type -> controlplane.v1.GetSessionRequest
-	6,  // 19: controlplane.v1.ControlPlaneService.SetupAdmin:input_type -> controlplane.v1.SetupAdminRequest
-	8,  // 20: controlplane.v1.ControlPlaneService.Login:input_type -> controlplane.v1.LoginRequest
-	10, // 21: controlplane.v1.ControlPlaneService.Logout:input_type -> controlplane.v1.LogoutRequest
-	12, // 22: controlplane.v1.ControlPlaneService.GetServiceInfo:input_type -> controlplane.v1.GetServiceInfoRequest
-	14, // 23: controlplane.v1.ControlPlaneService.GetDashboardSummary:input_type -> controlplane.v1.GetDashboardSummaryRequest
-	19, // 24: controlplane.v1.ControlPlaneService.ListRunnerSets:input_type -> controlplane.v1.ListRunnerSetsRequest
-	23, // 25: controlplane.v1.ControlPlaneService.ListJobRecords:input_type -> controlplane.v1.ListJobRecordsRequest
-	26, // 26: controlplane.v1.ControlPlaneService.GetMachineVitals:input_type -> controlplane.v1.GetMachineVitalsRequest
-	28, // 27: controlplane.v1.ControlPlaneService.GetConfigStatus:input_type -> controlplane.v1.GetConfigStatusRequest
-	30, // 28: controlplane.v1.ControlPlaneService.GetSystemInfo:input_type -> controlplane.v1.GetSystemInfoRequest
-	5,  // 29: controlplane.v1.ControlPlaneService.GetSession:output_type -> controlplane.v1.GetSessionResponse
-	7,  // 30: controlplane.v1.ControlPlaneService.SetupAdmin:output_type -> controlplane.v1.SetupAdminResponse
-	9,  // 31: controlplane.v1.ControlPlaneService.Login:output_type -> controlplane.v1.LoginResponse
-	11, // 32: controlplane.v1.ControlPlaneService.Logout:output_type -> controlplane.v1.LogoutResponse
-	13, // 33: controlplane.v1.ControlPlaneService.GetServiceInfo:output_type -> controlplane.v1.GetServiceInfoResponse
-	15, // 34: controlplane.v1.ControlPlaneService.GetDashboardSummary:output_type -> controlplane.v1.GetDashboardSummaryResponse
-	20, // 35: controlplane.v1.ControlPlaneService.ListRunnerSets:output_type -> controlplane.v1.ListRunnerSetsResponse
-	24, // 36: controlplane.v1.ControlPlaneService.ListJobRecords:output_type -> controlplane.v1.ListJobRecordsResponse
-	27, // 37: controlplane.v1.ControlPlaneService.GetMachineVitals:output_type -> controlplane.v1.GetMachineVitalsResponse
-	29, // 38: controlplane.v1.ControlPlaneService.GetConfigStatus:output_type -> controlplane.v1.GetConfigStatusResponse
-	31, // 39: controlplane.v1.ControlPlaneService.GetSystemInfo:output_type -> controlplane.v1.GetSystemInfoResponse
-	29, // [29:40] is the sub-list for method output_type
-	18, // [18:29] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	43, // 10: controlplane.v1.Runner.since:type_name -> google.protobuf.Timestamp
+	43, // 11: controlplane.v1.ListJobRecordsRequest.from:type_name -> google.protobuf.Timestamp
+	43, // 12: controlplane.v1.ListJobRecordsRequest.to:type_name -> google.protobuf.Timestamp
+	26, // 13: controlplane.v1.ListJobRecordsResponse.job_records:type_name -> controlplane.v1.JobRecord
+	2,  // 14: controlplane.v1.JobRecord.result:type_name -> controlplane.v1.JobResult
+	43, // 15: controlplane.v1.JobRecord.started_at:type_name -> google.protobuf.Timestamp
+	43, // 16: controlplane.v1.JobRecord.completed_at:type_name -> google.protobuf.Timestamp
+	43, // 17: controlplane.v1.JobRecord.queued_at:type_name -> google.protobuf.Timestamp
+	43, // 18: controlplane.v1.JobRecord.scale_set_assigned_at:type_name -> google.protobuf.Timestamp
+	43, // 19: controlplane.v1.JobRecord.runner_assigned_at:type_name -> google.protobuf.Timestamp
+	0,  // 20: controlplane.v1.JobRecord.backend:type_name -> controlplane.v1.Backend
+	26, // 21: controlplane.v1.GetJobDetailResponse.job:type_name -> controlplane.v1.JobRecord
+	43, // 22: controlplane.v1.JobLogLine.recorded_at:type_name -> google.protobuf.Timestamp
+	30, // 23: controlplane.v1.GetJobLogsResponse.lines:type_name -> controlplane.v1.JobLogLine
+	43, // 24: controlplane.v1.ResourceSample.recorded_at:type_name -> google.protobuf.Timestamp
+	3,  // 25: controlplane.v1.ResourceSample.accuracy:type_name -> controlplane.v1.ResourceAccuracy
+	32, // 26: controlplane.v1.GetJobResourceSamplesResponse.samples:type_name -> controlplane.v1.ResourceSample
+	43, // 27: controlplane.v1.GetHostResourceSamplesRequest.from:type_name -> google.protobuf.Timestamp
+	43, // 28: controlplane.v1.GetHostResourceSamplesRequest.to:type_name -> google.protobuf.Timestamp
+	32, // 29: controlplane.v1.GetHostResourceSamplesResponse.samples:type_name -> controlplane.v1.ResourceSample
+	43, // 30: controlplane.v1.GetHostResourceSamplesResponse.earliest_at:type_name -> google.protobuf.Timestamp
+	4,  // 31: controlplane.v1.GetConfigStatusResponse.state:type_name -> controlplane.v1.ConfigSyncState
+	43, // 32: controlplane.v1.GetConfigStatusResponse.disk_modified_at:type_name -> google.protobuf.Timestamp
+	43, // 33: controlplane.v1.GetConfigStatusResponse.active_loaded_at:type_name -> google.protobuf.Timestamp
+	5,  // 34: controlplane.v1.ControlPlaneService.GetSession:input_type -> controlplane.v1.GetSessionRequest
+	7,  // 35: controlplane.v1.ControlPlaneService.SetupAdmin:input_type -> controlplane.v1.SetupAdminRequest
+	9,  // 36: controlplane.v1.ControlPlaneService.Login:input_type -> controlplane.v1.LoginRequest
+	11, // 37: controlplane.v1.ControlPlaneService.Logout:input_type -> controlplane.v1.LogoutRequest
+	13, // 38: controlplane.v1.ControlPlaneService.GetServiceInfo:input_type -> controlplane.v1.GetServiceInfoRequest
+	15, // 39: controlplane.v1.ControlPlaneService.GetDashboardSummary:input_type -> controlplane.v1.GetDashboardSummaryRequest
+	20, // 40: controlplane.v1.ControlPlaneService.ListRunnerSets:input_type -> controlplane.v1.ListRunnerSetsRequest
+	24, // 41: controlplane.v1.ControlPlaneService.ListJobRecords:input_type -> controlplane.v1.ListJobRecordsRequest
+	27, // 42: controlplane.v1.ControlPlaneService.GetJobDetail:input_type -> controlplane.v1.GetJobDetailRequest
+	29, // 43: controlplane.v1.ControlPlaneService.GetJobLogs:input_type -> controlplane.v1.GetJobLogsRequest
+	33, // 44: controlplane.v1.ControlPlaneService.GetJobResourceSamples:input_type -> controlplane.v1.GetJobResourceSamplesRequest
+	35, // 45: controlplane.v1.ControlPlaneService.GetHostResourceSamples:input_type -> controlplane.v1.GetHostResourceSamplesRequest
+	37, // 46: controlplane.v1.ControlPlaneService.GetMachineVitals:input_type -> controlplane.v1.GetMachineVitalsRequest
+	39, // 47: controlplane.v1.ControlPlaneService.GetConfigStatus:input_type -> controlplane.v1.GetConfigStatusRequest
+	41, // 48: controlplane.v1.ControlPlaneService.GetSystemInfo:input_type -> controlplane.v1.GetSystemInfoRequest
+	6,  // 49: controlplane.v1.ControlPlaneService.GetSession:output_type -> controlplane.v1.GetSessionResponse
+	8,  // 50: controlplane.v1.ControlPlaneService.SetupAdmin:output_type -> controlplane.v1.SetupAdminResponse
+	10, // 51: controlplane.v1.ControlPlaneService.Login:output_type -> controlplane.v1.LoginResponse
+	12, // 52: controlplane.v1.ControlPlaneService.Logout:output_type -> controlplane.v1.LogoutResponse
+	14, // 53: controlplane.v1.ControlPlaneService.GetServiceInfo:output_type -> controlplane.v1.GetServiceInfoResponse
+	16, // 54: controlplane.v1.ControlPlaneService.GetDashboardSummary:output_type -> controlplane.v1.GetDashboardSummaryResponse
+	21, // 55: controlplane.v1.ControlPlaneService.ListRunnerSets:output_type -> controlplane.v1.ListRunnerSetsResponse
+	25, // 56: controlplane.v1.ControlPlaneService.ListJobRecords:output_type -> controlplane.v1.ListJobRecordsResponse
+	28, // 57: controlplane.v1.ControlPlaneService.GetJobDetail:output_type -> controlplane.v1.GetJobDetailResponse
+	31, // 58: controlplane.v1.ControlPlaneService.GetJobLogs:output_type -> controlplane.v1.GetJobLogsResponse
+	34, // 59: controlplane.v1.ControlPlaneService.GetJobResourceSamples:output_type -> controlplane.v1.GetJobResourceSamplesResponse
+	36, // 60: controlplane.v1.ControlPlaneService.GetHostResourceSamples:output_type -> controlplane.v1.GetHostResourceSamplesResponse
+	38, // 61: controlplane.v1.ControlPlaneService.GetMachineVitals:output_type -> controlplane.v1.GetMachineVitalsResponse
+	40, // 62: controlplane.v1.ControlPlaneService.GetConfigStatus:output_type -> controlplane.v1.GetConfigStatusResponse
+	42, // 63: controlplane.v1.ControlPlaneService.GetSystemInfo:output_type -> controlplane.v1.GetSystemInfoResponse
+	49, // [49:64] is the sub-list for method output_type
+	34, // [34:49] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_controlplane_v1_controlplane_proto_init() }
@@ -2059,15 +3005,18 @@ func file_controlplane_v1_controlplane_proto_init() {
 	if File_controlplane_v1_controlplane_proto != nil {
 		return
 	}
+	file_controlplane_v1_controlplane_proto_msgTypes[19].OneofWrappers = []any{}
 	file_controlplane_v1_controlplane_proto_msgTypes[21].OneofWrappers = []any{}
-	file_controlplane_v1_controlplane_proto_msgTypes[25].OneofWrappers = []any{}
+	file_controlplane_v1_controlplane_proto_msgTypes[30].OneofWrappers = []any{}
+	file_controlplane_v1_controlplane_proto_msgTypes[31].OneofWrappers = []any{}
+	file_controlplane_v1_controlplane_proto_msgTypes[35].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_controlplane_v1_controlplane_proto_rawDesc), len(file_controlplane_v1_controlplane_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   28,
+			NumEnums:      5,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/controlplane/v1/controlplanev1connect/controlplane.connect.go
+++ b/gen/controlplane/v1/controlplanev1connect/controlplane.connect.go
@@ -58,6 +58,18 @@ const (
 	// ControlPlaneServiceListJobRecordsProcedure is the fully-qualified name of the
 	// ControlPlaneService's ListJobRecords RPC.
 	ControlPlaneServiceListJobRecordsProcedure = "/controlplane.v1.ControlPlaneService/ListJobRecords"
+	// ControlPlaneServiceGetJobDetailProcedure is the fully-qualified name of the ControlPlaneService's
+	// GetJobDetail RPC.
+	ControlPlaneServiceGetJobDetailProcedure = "/controlplane.v1.ControlPlaneService/GetJobDetail"
+	// ControlPlaneServiceGetJobLogsProcedure is the fully-qualified name of the ControlPlaneService's
+	// GetJobLogs RPC.
+	ControlPlaneServiceGetJobLogsProcedure = "/controlplane.v1.ControlPlaneService/GetJobLogs"
+	// ControlPlaneServiceGetJobResourceSamplesProcedure is the fully-qualified name of the
+	// ControlPlaneService's GetJobResourceSamples RPC.
+	ControlPlaneServiceGetJobResourceSamplesProcedure = "/controlplane.v1.ControlPlaneService/GetJobResourceSamples"
+	// ControlPlaneServiceGetHostResourceSamplesProcedure is the fully-qualified name of the
+	// ControlPlaneService's GetHostResourceSamples RPC.
+	ControlPlaneServiceGetHostResourceSamplesProcedure = "/controlplane.v1.ControlPlaneService/GetHostResourceSamples"
 	// ControlPlaneServiceGetMachineVitalsProcedure is the fully-qualified name of the
 	// ControlPlaneService's GetMachineVitals RPC.
 	ControlPlaneServiceGetMachineVitalsProcedure = "/controlplane.v1.ControlPlaneService/GetMachineVitals"
@@ -85,6 +97,10 @@ type ControlPlaneServiceClient interface {
 	// ListJobRecords returns a bounded history of job executions
 	// across all runner sets, ordered most-recent-first.
 	ListJobRecords(context.Context, *connect.Request[v1.ListJobRecordsRequest]) (*connect.Response[v1.ListJobRecordsResponse], error)
+	GetJobDetail(context.Context, *connect.Request[v1.GetJobDetailRequest]) (*connect.Response[v1.GetJobDetailResponse], error)
+	GetJobLogs(context.Context, *connect.Request[v1.GetJobLogsRequest]) (*connect.Response[v1.GetJobLogsResponse], error)
+	GetJobResourceSamples(context.Context, *connect.Request[v1.GetJobResourceSamplesRequest]) (*connect.Response[v1.GetJobResourceSamplesResponse], error)
+	GetHostResourceSamples(context.Context, *connect.Request[v1.GetHostResourceSamplesRequest]) (*connect.Response[v1.GetHostResourceSamplesResponse], error)
 	// GetMachineVitals returns a point-in-time snapshot of host-level
 	// resource metrics (CPU, memory, disk, temperature).
 	GetMachineVitals(context.Context, *connect.Request[v1.GetMachineVitalsRequest]) (*connect.Response[v1.GetMachineVitalsResponse], error)
@@ -151,6 +167,30 @@ func NewControlPlaneServiceClient(httpClient connect.HTTPClient, baseURL string,
 			connect.WithSchema(controlPlaneServiceMethods.ByName("ListJobRecords")),
 			connect.WithClientOptions(opts...),
 		),
+		getJobDetail: connect.NewClient[v1.GetJobDetailRequest, v1.GetJobDetailResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceGetJobDetailProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("GetJobDetail")),
+			connect.WithClientOptions(opts...),
+		),
+		getJobLogs: connect.NewClient[v1.GetJobLogsRequest, v1.GetJobLogsResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceGetJobLogsProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("GetJobLogs")),
+			connect.WithClientOptions(opts...),
+		),
+		getJobResourceSamples: connect.NewClient[v1.GetJobResourceSamplesRequest, v1.GetJobResourceSamplesResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceGetJobResourceSamplesProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("GetJobResourceSamples")),
+			connect.WithClientOptions(opts...),
+		),
+		getHostResourceSamples: connect.NewClient[v1.GetHostResourceSamplesRequest, v1.GetHostResourceSamplesResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceGetHostResourceSamplesProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("GetHostResourceSamples")),
+			connect.WithClientOptions(opts...),
+		),
 		getMachineVitals: connect.NewClient[v1.GetMachineVitalsRequest, v1.GetMachineVitalsResponse](
 			httpClient,
 			baseURL+ControlPlaneServiceGetMachineVitalsProcedure,
@@ -174,17 +214,21 @@ func NewControlPlaneServiceClient(httpClient connect.HTTPClient, baseURL string,
 
 // controlPlaneServiceClient implements ControlPlaneServiceClient.
 type controlPlaneServiceClient struct {
-	getSession          *connect.Client[v1.GetSessionRequest, v1.GetSessionResponse]
-	setupAdmin          *connect.Client[v1.SetupAdminRequest, v1.SetupAdminResponse]
-	login               *connect.Client[v1.LoginRequest, v1.LoginResponse]
-	logout              *connect.Client[v1.LogoutRequest, v1.LogoutResponse]
-	getServiceInfo      *connect.Client[v1.GetServiceInfoRequest, v1.GetServiceInfoResponse]
-	getDashboardSummary *connect.Client[v1.GetDashboardSummaryRequest, v1.GetDashboardSummaryResponse]
-	listRunnerSets      *connect.Client[v1.ListRunnerSetsRequest, v1.ListRunnerSetsResponse]
-	listJobRecords      *connect.Client[v1.ListJobRecordsRequest, v1.ListJobRecordsResponse]
-	getMachineVitals    *connect.Client[v1.GetMachineVitalsRequest, v1.GetMachineVitalsResponse]
-	getConfigStatus     *connect.Client[v1.GetConfigStatusRequest, v1.GetConfigStatusResponse]
-	getSystemInfo       *connect.Client[v1.GetSystemInfoRequest, v1.GetSystemInfoResponse]
+	getSession             *connect.Client[v1.GetSessionRequest, v1.GetSessionResponse]
+	setupAdmin             *connect.Client[v1.SetupAdminRequest, v1.SetupAdminResponse]
+	login                  *connect.Client[v1.LoginRequest, v1.LoginResponse]
+	logout                 *connect.Client[v1.LogoutRequest, v1.LogoutResponse]
+	getServiceInfo         *connect.Client[v1.GetServiceInfoRequest, v1.GetServiceInfoResponse]
+	getDashboardSummary    *connect.Client[v1.GetDashboardSummaryRequest, v1.GetDashboardSummaryResponse]
+	listRunnerSets         *connect.Client[v1.ListRunnerSetsRequest, v1.ListRunnerSetsResponse]
+	listJobRecords         *connect.Client[v1.ListJobRecordsRequest, v1.ListJobRecordsResponse]
+	getJobDetail           *connect.Client[v1.GetJobDetailRequest, v1.GetJobDetailResponse]
+	getJobLogs             *connect.Client[v1.GetJobLogsRequest, v1.GetJobLogsResponse]
+	getJobResourceSamples  *connect.Client[v1.GetJobResourceSamplesRequest, v1.GetJobResourceSamplesResponse]
+	getHostResourceSamples *connect.Client[v1.GetHostResourceSamplesRequest, v1.GetHostResourceSamplesResponse]
+	getMachineVitals       *connect.Client[v1.GetMachineVitalsRequest, v1.GetMachineVitalsResponse]
+	getConfigStatus        *connect.Client[v1.GetConfigStatusRequest, v1.GetConfigStatusResponse]
+	getSystemInfo          *connect.Client[v1.GetSystemInfoRequest, v1.GetSystemInfoResponse]
 }
 
 // GetSession calls controlplane.v1.ControlPlaneService.GetSession.
@@ -227,6 +271,26 @@ func (c *controlPlaneServiceClient) ListJobRecords(ctx context.Context, req *con
 	return c.listJobRecords.CallUnary(ctx, req)
 }
 
+// GetJobDetail calls controlplane.v1.ControlPlaneService.GetJobDetail.
+func (c *controlPlaneServiceClient) GetJobDetail(ctx context.Context, req *connect.Request[v1.GetJobDetailRequest]) (*connect.Response[v1.GetJobDetailResponse], error) {
+	return c.getJobDetail.CallUnary(ctx, req)
+}
+
+// GetJobLogs calls controlplane.v1.ControlPlaneService.GetJobLogs.
+func (c *controlPlaneServiceClient) GetJobLogs(ctx context.Context, req *connect.Request[v1.GetJobLogsRequest]) (*connect.Response[v1.GetJobLogsResponse], error) {
+	return c.getJobLogs.CallUnary(ctx, req)
+}
+
+// GetJobResourceSamples calls controlplane.v1.ControlPlaneService.GetJobResourceSamples.
+func (c *controlPlaneServiceClient) GetJobResourceSamples(ctx context.Context, req *connect.Request[v1.GetJobResourceSamplesRequest]) (*connect.Response[v1.GetJobResourceSamplesResponse], error) {
+	return c.getJobResourceSamples.CallUnary(ctx, req)
+}
+
+// GetHostResourceSamples calls controlplane.v1.ControlPlaneService.GetHostResourceSamples.
+func (c *controlPlaneServiceClient) GetHostResourceSamples(ctx context.Context, req *connect.Request[v1.GetHostResourceSamplesRequest]) (*connect.Response[v1.GetHostResourceSamplesResponse], error) {
+	return c.getHostResourceSamples.CallUnary(ctx, req)
+}
+
 // GetMachineVitals calls controlplane.v1.ControlPlaneService.GetMachineVitals.
 func (c *controlPlaneServiceClient) GetMachineVitals(ctx context.Context, req *connect.Request[v1.GetMachineVitalsRequest]) (*connect.Response[v1.GetMachineVitalsResponse], error) {
 	return c.getMachineVitals.CallUnary(ctx, req)
@@ -259,6 +323,10 @@ type ControlPlaneServiceHandler interface {
 	// ListJobRecords returns a bounded history of job executions
 	// across all runner sets, ordered most-recent-first.
 	ListJobRecords(context.Context, *connect.Request[v1.ListJobRecordsRequest]) (*connect.Response[v1.ListJobRecordsResponse], error)
+	GetJobDetail(context.Context, *connect.Request[v1.GetJobDetailRequest]) (*connect.Response[v1.GetJobDetailResponse], error)
+	GetJobLogs(context.Context, *connect.Request[v1.GetJobLogsRequest]) (*connect.Response[v1.GetJobLogsResponse], error)
+	GetJobResourceSamples(context.Context, *connect.Request[v1.GetJobResourceSamplesRequest]) (*connect.Response[v1.GetJobResourceSamplesResponse], error)
+	GetHostResourceSamples(context.Context, *connect.Request[v1.GetHostResourceSamplesRequest]) (*connect.Response[v1.GetHostResourceSamplesResponse], error)
 	// GetMachineVitals returns a point-in-time snapshot of host-level
 	// resource metrics (CPU, memory, disk, temperature).
 	GetMachineVitals(context.Context, *connect.Request[v1.GetMachineVitalsRequest]) (*connect.Response[v1.GetMachineVitalsResponse], error)
@@ -321,6 +389,30 @@ func NewControlPlaneServiceHandler(svc ControlPlaneServiceHandler, opts ...conne
 		connect.WithSchema(controlPlaneServiceMethods.ByName("ListJobRecords")),
 		connect.WithHandlerOptions(opts...),
 	)
+	controlPlaneServiceGetJobDetailHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceGetJobDetailProcedure,
+		svc.GetJobDetail,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("GetJobDetail")),
+		connect.WithHandlerOptions(opts...),
+	)
+	controlPlaneServiceGetJobLogsHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceGetJobLogsProcedure,
+		svc.GetJobLogs,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("GetJobLogs")),
+		connect.WithHandlerOptions(opts...),
+	)
+	controlPlaneServiceGetJobResourceSamplesHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceGetJobResourceSamplesProcedure,
+		svc.GetJobResourceSamples,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("GetJobResourceSamples")),
+		connect.WithHandlerOptions(opts...),
+	)
+	controlPlaneServiceGetHostResourceSamplesHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceGetHostResourceSamplesProcedure,
+		svc.GetHostResourceSamples,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("GetHostResourceSamples")),
+		connect.WithHandlerOptions(opts...),
+	)
 	controlPlaneServiceGetMachineVitalsHandler := connect.NewUnaryHandler(
 		ControlPlaneServiceGetMachineVitalsProcedure,
 		svc.GetMachineVitals,
@@ -357,6 +449,14 @@ func NewControlPlaneServiceHandler(svc ControlPlaneServiceHandler, opts ...conne
 			controlPlaneServiceListRunnerSetsHandler.ServeHTTP(w, r)
 		case ControlPlaneServiceListJobRecordsProcedure:
 			controlPlaneServiceListJobRecordsHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceGetJobDetailProcedure:
+			controlPlaneServiceGetJobDetailHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceGetJobLogsProcedure:
+			controlPlaneServiceGetJobLogsHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceGetJobResourceSamplesProcedure:
+			controlPlaneServiceGetJobResourceSamplesHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceGetHostResourceSamplesProcedure:
+			controlPlaneServiceGetHostResourceSamplesHandler.ServeHTTP(w, r)
 		case ControlPlaneServiceGetMachineVitalsProcedure:
 			controlPlaneServiceGetMachineVitalsHandler.ServeHTTP(w, r)
 		case ControlPlaneServiceGetConfigStatusProcedure:
@@ -402,6 +502,22 @@ func (UnimplementedControlPlaneServiceHandler) ListRunnerSets(context.Context, *
 
 func (UnimplementedControlPlaneServiceHandler) ListJobRecords(context.Context, *connect.Request[v1.ListJobRecordsRequest]) (*connect.Response[v1.ListJobRecordsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.ListJobRecords is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) GetJobDetail(context.Context, *connect.Request[v1.GetJobDetailRequest]) (*connect.Response[v1.GetJobDetailResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.GetJobDetail is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) GetJobLogs(context.Context, *connect.Request[v1.GetJobLogsRequest]) (*connect.Response[v1.GetJobLogsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.GetJobLogs is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) GetJobResourceSamples(context.Context, *connect.Request[v1.GetJobResourceSamplesRequest]) (*connect.Response[v1.GetJobResourceSamplesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.GetJobResourceSamples is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) GetHostResourceSamples(context.Context, *connect.Request[v1.GetHostResourceSamplesRequest]) (*connect.Response[v1.GetHostResourceSamplesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.GetHostResourceSamples is not implemented"))
 }
 
 func (UnimplementedControlPlaneServiceHandler) GetMachineVitals(context.Context, *connect.Request[v1.GetMachineVitalsRequest]) (*connect.Response[v1.GetMachineVitalsResponse], error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -284,25 +284,153 @@ func (s *Server) ListRunnerSets(_ context.Context, _ *connect.Request[controlpla
 	}), nil
 }
 
-func (s *Server) ListJobRecords(_ context.Context, _ *connect.Request[controlplanev1.ListJobRecordsRequest]) (*connect.Response[controlplanev1.ListJobRecordsResponse], error) {
-	jobs := s.managementService.ListJobRecords()
+func (s *Server) ListJobRecords(_ context.Context, req *connect.Request[controlplanev1.ListJobRecordsRequest]) (*connect.Response[controlplanev1.ListJobRecordsResponse], error) {
+	cursor, _ := strconv.Atoi(req.Msg.Cursor)
+	filter := management.JobFilter{
+		Status:     req.Msg.Status,
+		RunnerSet:  req.Msg.RunnerSet,
+		Repository: req.Msg.Repository,
+		Workflow:   req.Msg.Workflow,
+		Cursor:     cursor,
+		PageSize:   int(req.Msg.PageSize),
+	}
+	if req.Msg.From != nil {
+		value := req.Msg.From.AsTime()
+		filter.From = &value
+	}
+	if req.Msg.To != nil {
+		value := req.Msg.To.AsTime()
+		filter.To = &value
+	}
+	page := s.managementService.FindJobRecords(filter)
+	jobs := page.Records
 	records := make([]*controlplanev1.JobRecord, 0, len(jobs))
 	for _, j := range jobs {
-		rec := &controlplanev1.JobRecord{
-			Id:            j.ID,
-			RunnerName:    j.RunnerName,
-			RunnerSetName: j.RunnerSetName,
-			Result:        toProtoJobResult(j.Result),
-			StartedAt:     timestamppb.New(j.StartedAt),
-		}
-		if j.CompletedAt != nil {
-			rec.CompletedAt = timestamppb.New(*j.CompletedAt)
-		}
-		records = append(records, rec)
+		records = append(records, toProtoJob(j))
 	}
 	return connect.NewResponse(&controlplanev1.ListJobRecordsResponse{
 		JobRecords: records,
+		NextCursor: page.NextCursor,
 	}), nil
+}
+
+func (s *Server) GetJobDetail(_ context.Context, req *connect.Request[controlplanev1.GetJobDetailRequest]) (*connect.Response[controlplanev1.GetJobDetailResponse], error) {
+	job, err := s.managementService.GetJobRecord(req.Msg.Id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("job record was not found"))
+	}
+	return connect.NewResponse(&controlplanev1.GetJobDetailResponse{Job: toProtoJob(*job)}), nil
+}
+
+func (s *Server) GetJobLogs(_ context.Context, req *connect.Request[controlplanev1.GetJobLogsRequest]) (*connect.Response[controlplanev1.GetJobLogsResponse], error) {
+	logs, next := s.managementService.GetJobLogs(req.Msg.JobId, req.Msg.AfterSequence, int(req.Msg.PageSize))
+	lines := make([]*controlplanev1.JobLogLine, 0, len(logs))
+	for _, line := range logs {
+		lines = append(lines, &controlplanev1.JobLogLine{
+			Sequence:   line.Sequence,
+			RecordedAt: timestamppb.New(line.RecordedAt),
+			Text:       line.Text,
+		})
+	}
+	return connect.NewResponse(&controlplanev1.GetJobLogsResponse{Lines: lines, NextSequence: next}), nil
+}
+
+func (s *Server) GetJobResourceSamples(_ context.Context, req *connect.Request[controlplanev1.GetJobResourceSamplesRequest]) (*connect.Response[controlplanev1.GetJobResourceSamplesResponse], error) {
+	samples := s.managementService.GetJobSamples(req.Msg.JobId)
+	result := make([]*controlplanev1.ResourceSample, 0, len(samples))
+	for _, sample := range samples {
+		result = append(result, toProtoResourceSample(sample))
+	}
+	return connect.NewResponse(&controlplanev1.GetJobResourceSamplesResponse{Samples: result}), nil
+}
+
+func (s *Server) GetHostResourceSamples(_ context.Context, req *connect.Request[controlplanev1.GetHostResourceSamplesRequest]) (*connect.Response[controlplanev1.GetHostResourceSamplesResponse], error) {
+	to := time.Now()
+	from := to.Add(-time.Hour)
+	if req.Msg.From != nil {
+		from = req.Msg.From.AsTime()
+	}
+	if req.Msg.To != nil {
+		to = req.Msg.To.AsTime()
+	}
+	samples, earliest := s.managementService.HostSamples(from, to)
+	result := make([]*controlplanev1.ResourceSample, 0, len(samples))
+	for _, sample := range samples {
+		result = append(result, &controlplanev1.ResourceSample{
+			RecordedAt:           timestamppb.New(sample.RecordedAt),
+			Source:               "host",
+			Accuracy:             controlplanev1.ResourceAccuracy_RESOURCE_ACCURACY_EXACT,
+			CpuPercent:           sample.CPUPercent,
+			MemoryUsedBytes:      sample.MemoryUsedBytes,
+			MemoryAvailableBytes: sample.MemoryAvailableBytes,
+			DiskUsedBytes:        sample.DiskUsedBytes,
+			DiskAvailableBytes:   sample.DiskAvailableBytes,
+			DiskReadBytes:        sample.DiskReadBytes,
+			DiskWriteBytes:       sample.DiskWriteBytes,
+			LoadOne:              sample.LoadOne,
+			TemperatureCelsius:   sample.TemperatureCelsius,
+		})
+	}
+	response := &controlplanev1.GetHostResourceSamplesResponse{Samples: result}
+	if earliest != nil {
+		response.EarliestAt = timestamppb.New(*earliest)
+	}
+	return connect.NewResponse(response), nil
+}
+
+func toProtoJob(job management.JobRecord) *controlplanev1.JobRecord {
+	record := &controlplanev1.JobRecord{
+		Id:            job.ID,
+		RunnerName:    job.RunnerName,
+		RunnerSetName: job.RunnerSetName,
+		Result:        toProtoJobResult(job.Result),
+		StartedAt:     timestamppb.New(job.StartedAt),
+		Owner:         job.Owner,
+		Repository:    job.Repository,
+		WorkflowRef:   job.WorkflowRef,
+		DisplayName:   job.DisplayName,
+		WorkflowRunId: job.WorkflowRunID,
+		EventName:     job.EventName,
+		Labels:        job.Labels,
+		Backend:       toProtoBackend(job.Backend),
+	}
+	if job.Owner != "" && job.Repository != "" && job.WorkflowRunID > 0 {
+		record.ActionsUrl = "https://github.com/" + job.Owner + "/" + job.Repository + "/actions/runs/" + strconv.FormatInt(job.WorkflowRunID, 10)
+	}
+	if job.CompletedAt != nil {
+		record.CompletedAt = timestamppb.New(*job.CompletedAt)
+	}
+	if job.QueuedAt != nil {
+		record.QueuedAt = timestamppb.New(*job.QueuedAt)
+	}
+	if job.ScaleSetAssignedAt != nil {
+		record.ScaleSetAssignedAt = timestamppb.New(*job.ScaleSetAssignedAt)
+	}
+	if job.RunnerAssignedAt != nil {
+		record.RunnerAssignedAt = timestamppb.New(*job.RunnerAssignedAt)
+	}
+	return record
+}
+
+func toProtoResourceSample(sample management.ResourceSample) *controlplanev1.ResourceSample {
+	accuracy := controlplanev1.ResourceAccuracy_RESOURCE_ACCURACY_EXACT
+	if sample.Accuracy == "estimate" {
+		accuracy = controlplanev1.ResourceAccuracy_RESOURCE_ACCURACY_ESTIMATE
+	}
+	return &controlplanev1.ResourceSample{
+		RecordedAt:           timestamppb.New(sample.RecordedAt),
+		Source:               sample.Source,
+		Accuracy:             accuracy,
+		CpuPercent:           sample.CPUPercent,
+		MemoryUsedBytes:      sample.MemoryUsedBytes,
+		MemoryAvailableBytes: sample.MemoryAvailableBytes,
+		DiskUsedBytes:        sample.DiskUsedBytes,
+		DiskAvailableBytes:   sample.DiskAvailableBytes,
+		DiskReadBytes:        sample.DiskReadBytes,
+		DiskWriteBytes:       sample.DiskWriteBytes,
+		NetworkReceiveBytes:  sample.NetworkReceiveBytes,
+		NetworkSendBytes:     sample.NetworkSendBytes,
+	}
 }
 
 func (s *Server) GetMachineVitals(_ context.Context, _ *connect.Request[controlplanev1.GetMachineVitalsRequest]) (*connect.Response[controlplanev1.GetMachineVitalsResponse], error) {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -1,6 +1,9 @@
 package backend
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Backend abstracts the runner execution environment.
 // Implementations handle the full lifecycle: start the GitHub Actions runner
@@ -18,4 +21,26 @@ type Backend interface {
 	// CleanupAll removes all resources whose name starts with prefix.
 	// Called once at controller startup to ensure a clean slate.
 	CleanupAll(ctx context.Context, prefix string)
+}
+
+// ResourceSample is a resource reading from a runner backend.
+type ResourceSample struct {
+	RecordedAt           time.Time
+	Source               string
+	Accuracy             string
+	CPUPercent           float64
+	MemoryUsedBytes      int64
+	MemoryAvailableBytes int64
+	DiskUsedBytes        int64
+	DiskAvailableBytes   int64
+	DiskReadBytes        int64
+	DiskWriteBytes       int64
+	NetworkReceiveBytes  int64
+	NetworkSendBytes     int64
+}
+
+// Diagnostics reads logs and resource data before a runner is removed.
+type Diagnostics interface {
+	ReadLogs(ctx context.Context, name string) (string, error)
+	ReadResource(ctx context.Context, name string) (ResourceSample, error)
 }

--- a/internal/backend/docker.go
+++ b/internal/backend/docker.go
@@ -2,10 +2,13 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/boring-design/elastic-fruit-runner/internal/binpath"
 	"go.opentelemetry.io/otel"
@@ -13,6 +16,13 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
+
+type dockerStats struct {
+	CPUPercent string `json:"CPUPerc"`
+	Memory     string `json:"MemUsage"`
+	Network    string `json:"NetIO"`
+	Block      string `json:"BlockIO"`
+}
 
 var dockerTracer = otel.Tracer("github.com/boring-design/elastic-fruit-runner/internal/backend/docker")
 
@@ -114,4 +124,73 @@ func (b *DockerBackend) CleanupAll(ctx context.Context, prefix string) {
 		b.logger.Info("removing orphaned container", "container", name)
 		b.Cleanup(ctx, name)
 	}
+}
+
+func (b *DockerBackend) ReadLogs(ctx context.Context, name string) (string, error) {
+	cmd := exec.CommandContext(ctx, binpath.Lookup("docker"), "logs", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("read Docker logs for %s: %w: %s", name, err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func (b *DockerBackend) ReadResource(ctx context.Context, name string) (ResourceSample, error) {
+	cmd := exec.CommandContext(ctx, binpath.Lookup("docker"), "stats", "--no-stream", "--format", "{{json .}}", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return ResourceSample{}, fmt.Errorf("read Docker resource data for %s: %w: %s", name, err, strings.TrimSpace(string(out)))
+	}
+	var stats dockerStats
+	if err := json.Unmarshal(out, &stats); err != nil {
+		return ResourceSample{}, fmt.Errorf("parse Docker resource data for %s: %w", name, err)
+	}
+	memoryUsed, memoryAvailable := parsePair(stats.Memory)
+	networkReceive, networkSend := parsePair(stats.Network)
+	diskRead, diskWrite := parsePair(stats.Block)
+	cpu, _ := strconv.ParseFloat(strings.TrimSuffix(strings.TrimSpace(stats.CPUPercent), "%"), 64)
+	return ResourceSample{
+		RecordedAt:           time.Now(),
+		Source:               "docker",
+		Accuracy:             "exact",
+		CPUPercent:           cpu,
+		MemoryUsedBytes:      memoryUsed,
+		MemoryAvailableBytes: memoryAvailable,
+		DiskReadBytes:        diskRead,
+		DiskWriteBytes:       diskWrite,
+		NetworkReceiveBytes:  networkReceive,
+		NetworkSendBytes:     networkSend,
+	}, nil
+}
+
+func parsePair(value string) (first, second int64) {
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	return parseSize(parts[0]), parseSize(parts[1])
+}
+
+func parseSize(value string) int64 {
+	value = strings.TrimSpace(value)
+	units := []struct {
+		name   string
+		factor float64
+	}{
+		{"KiB", 1024}, {"MiB", 1024 * 1024}, {"GiB", 1024 * 1024 * 1024},
+		{"TiB", 1024 * 1024 * 1024 * 1024}, {"kB", 1000}, {"KB", 1000},
+		{"MB", 1000 * 1000}, {"GB", 1000 * 1000 * 1000},
+		{"TB", 1000 * 1000 * 1000 * 1000}, {"B", 1},
+	}
+	for _, unit := range units {
+		if strings.HasSuffix(value, unit.name) {
+			number := strings.TrimSpace(strings.TrimSuffix(value, unit.name))
+			parsed, err := strconv.ParseFloat(number, 64)
+			if err == nil {
+				return int64(parsed * unit.factor)
+			}
+			return 0
+		}
+	}
+	return 0
 }

--- a/internal/backend/tart.go
+++ b/internal/backend/tart.go
@@ -2,17 +2,27 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os/exec"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/boring-design/elastic-fruit-runner/internal/binpath"
 	"github.com/boring-design/elastic-fruit-runner/internal/tart"
 )
+
+type tartInfo struct {
+	CPU    int   `json:"CPU"`
+	Memory int64 `json:"Memory"`
+	Disk   int64 `json:"Disk"`
+}
 
 // isRemoteImage returns true if the image looks like a registry reference
 // (e.g. "ghcr.io/cirruslabs/macos-tahoe-xcode:26.3") rather than a local
@@ -154,4 +164,31 @@ func (b *TartBackend) CleanupAll(ctx context.Context, prefix string) {
 			b.Cleanup(ctx, name)
 		}
 	}
+}
+
+func (b *TartBackend) ReadLogs(ctx context.Context, name string) (string, error) {
+	out, err := b.tart.ExecOutput(ctx, name, "tail", "-n", "5000", "/tmp/runner.log")
+	if err != nil {
+		return "", fmt.Errorf("read Tart runner log for %s: %w", name, err)
+	}
+	return out, nil
+}
+
+func (b *TartBackend) ReadResource(ctx context.Context, name string) (ResourceSample, error) {
+	cmd := exec.CommandContext(ctx, binpath.Lookup("tart"), "get", name, "--format", "json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return ResourceSample{}, fmt.Errorf("read Tart allocation for %s: %w: %s", name, err, strings.TrimSpace(string(out)))
+	}
+	var info tartInfo
+	if err := json.Unmarshal(out, &info); err != nil {
+		return ResourceSample{}, fmt.Errorf("parse Tart allocation for %s: %w", name, err)
+	}
+	return ResourceSample{
+		RecordedAt:           time.Now(),
+		Source:               "tart",
+		Accuracy:             "estimate",
+		MemoryAvailableBytes: info.Memory * 1024 * 1024,
+		DiskAvailableBytes:   info.Disk * 1000 * 1000 * 1000,
+	}, nil
 }

--- a/internal/controller/scaler.go
+++ b/internal/controller/scaler.go
@@ -13,6 +13,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/boring-design/elastic-fruit-runner/internal/backend"
 )
 
 const reaperInterval = time.Minute
@@ -72,7 +74,8 @@ func (d *ScaleSetController) HandleJobStarted(ctx context.Context, job *scaleset
 	defer span.End()
 
 	d.runners.markBusy(job.RunnerName)
-	d.jobRecorder.RecordJobStarted(d.rsCfg.Name, job.JobID, job.RunnerName)
+	diagnostics, _ := d.backend.(backend.Diagnostics)
+	d.jobRecorder.RecordJobMessageStarted(d.rsCfg.Name, d.rsCfg.Backend, diagnostics, job)
 	d.logger.Info("job started", "runner", job.RunnerName, "id", job.RunnerID)
 	return nil
 }
@@ -90,7 +93,7 @@ func (d *ScaleSetController) HandleJobCompleted(ctx context.Context, job *scales
 
 	name := job.RunnerName
 	d.runners.markDone(name)
-	d.jobRecorder.RecordJobCompleted(job.JobID, job.Result)
+	d.jobRecorder.RecordJobMessageCompleted(job)
 	d.logger.Info("job completed", "runner", name, "result", job.Result)
 
 	go func() {

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -1,6 +1,12 @@
 package controller
 
-import "time"
+import (
+	"time"
+
+	"github.com/actions/scaleset"
+
+	"github.com/boring-design/elastic-fruit-runner/internal/backend"
+)
 
 // RunnerState represents the lifecycle phase of a runner.
 type RunnerState int
@@ -30,6 +36,6 @@ type RunnerSnapshot struct {
 // JobRecorder records job lifecycle events.
 // Implemented by the management service; injected into controllers.
 type JobRecorder interface {
-	RecordJobStarted(setName, jobID, runnerName string)
-	RecordJobCompleted(jobID, result string)
+	RecordJobMessageStarted(setName, backendName string, diagnostics backend.Diagnostics, job *scaleset.JobStarted)
+	RecordJobMessageCompleted(job *scaleset.JobCompleted)
 }

--- a/internal/management/host.go
+++ b/internal/management/host.go
@@ -1,0 +1,161 @@
+package management
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/boring-design/elastic-fruit-runner/internal/vitals"
+)
+
+const (
+	rawHostRetention   = 24 * time.Hour
+	historyRetention   = 30 * 24 * time.Hour
+	maxHistoryBytes    = int64(10 * 1024 * 1024 * 1024)
+	targetHistoryBytes = int64(9 * 1024 * 1024 * 1024)
+)
+
+type HostSample struct {
+	RecordedAt           time.Time
+	IntervalSeconds      int
+	CPUPercent           float64
+	MemoryUsedBytes      int64
+	MemoryAvailableBytes int64
+	DiskUsedBytes        int64
+	DiskAvailableBytes   int64
+	DiskReadBytes        int64
+	DiskWriteBytes       int64
+	LoadOne              float64
+	TemperatureCelsius   float64
+}
+
+func (svc *Service) RecordHostVitals(value vitals.Vitals) {
+	now := time.Now().UTC()
+	_, err := svc.db.ExecContext(context.Background(), `
+		INSERT INTO host_resource_samples (
+			recorded_at, interval_seconds, cpu_percent, memory_used_bytes,
+			memory_available_bytes, disk_used_bytes, disk_available_bytes,
+			disk_read_bytes, disk_write_bytes, load_one, temperature_celsius
+		) VALUES (?, 5, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		now, value.CPUUsagePercent, value.MemoryUsedBytes, value.MemoryAvailableBytes,
+		value.DiskUsedBytes, value.DiskAvailableBytes, value.DiskReadBytes,
+		value.DiskWriteBytes, value.LoadOne, value.TemperatureCelsius,
+	)
+	if err != nil {
+		slog.Warn("failed to record host resource data", "err", err)
+		return
+	}
+	svc.hostSampleCount++
+	if svc.hostSampleCount%12 == 0 {
+		svc.rollupHostMinute(now)
+		svc.cleanHistory(now)
+	}
+}
+
+func (svc *Service) rollupHostMinute(now time.Time) {
+	minute := now.Truncate(time.Minute).Add(-time.Minute)
+	next := minute.Add(time.Minute)
+	_, err := svc.db.ExecContext(context.Background(), `
+		INSERT OR REPLACE INTO host_resource_samples (
+			recorded_at, interval_seconds, cpu_percent, memory_used_bytes,
+			memory_available_bytes, disk_used_bytes, disk_available_bytes,
+			disk_read_bytes, disk_write_bytes, load_one, temperature_celsius
+		)
+		SELECT ?, 60, AVG(cpu_percent), AVG(memory_used_bytes),
+			AVG(memory_available_bytes), AVG(disk_used_bytes), AVG(disk_available_bytes),
+			MAX(disk_read_bytes), MAX(disk_write_bytes), AVG(load_one),
+			AVG(temperature_celsius)
+		FROM host_resource_samples
+		WHERE interval_seconds = 5 AND recorded_at >= ? AND recorded_at < ?`,
+		minute, minute, next,
+	)
+	if err != nil {
+		slog.Warn("failed to roll up host resource data", "minute", minute, "err", err)
+	}
+}
+
+func (svc *Service) cleanHistory(now time.Time) {
+	ctx := context.Background()
+	_, _ = svc.db.ExecContext(ctx, `
+		DELETE FROM host_resource_samples
+		WHERE (interval_seconds = 5 AND recorded_at < ?)
+			OR recorded_at < ?`,
+		now.Add(-rawHostRetention), now.Add(-historyRetention),
+	)
+	_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_logs WHERE recorded_at < ?`, now.Add(-historyRetention))
+	_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_resource_samples WHERE recorded_at < ?`, now.Add(-historyRetention))
+
+	if databaseSize(svc.databasePath) <= maxHistoryBytes {
+		return
+	}
+	for databaseSize(svc.databasePath) > targetHistoryBytes {
+		var jobID string
+		err := svc.db.QueryRowContext(ctx, `
+			SELECT id FROM jobs
+			WHERE result != 'running'
+			ORDER BY COALESCE(completed_at, started_at)
+			LIMIT 1`).Scan(&jobID)
+		if err != nil {
+			break
+		}
+		_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_logs WHERE job_id = ?`, jobID)
+		_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_resource_samples WHERE job_id = ?`, jobID)
+		_, _ = svc.db.ExecContext(ctx, `DELETE FROM jobs WHERE id = ? AND result != 'running'`, jobID)
+	}
+	_, _ = svc.db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
+}
+
+func (svc *Service) HostSamples(from, to time.Time) ([]HostSample, *time.Time) {
+	interval := 60
+	if from.After(time.Now().Add(-rawHostRetention)) {
+		interval = 5
+	}
+	rows, err := svc.db.QueryContext(context.Background(), `
+		SELECT recorded_at, interval_seconds, cpu_percent, memory_used_bytes,
+			memory_available_bytes, disk_used_bytes, disk_available_bytes,
+			disk_read_bytes, disk_write_bytes, load_one, temperature_celsius
+		FROM host_resource_samples
+		WHERE interval_seconds = ? AND recorded_at >= ? AND recorded_at <= ?
+		ORDER BY recorded_at`, interval, from, to)
+	if err != nil {
+		return nil, nil
+	}
+	defer rows.Close()
+	var samples []HostSample
+	for rows.Next() {
+		var sample HostSample
+		if err := rows.Scan(
+			&sample.RecordedAt, &sample.IntervalSeconds, &sample.CPUPercent,
+			&sample.MemoryUsedBytes, &sample.MemoryAvailableBytes,
+			&sample.DiskUsedBytes, &sample.DiskAvailableBytes,
+			&sample.DiskReadBytes, &sample.DiskWriteBytes, &sample.LoadOne,
+			&sample.TemperatureCelsius,
+		); err == nil {
+			samples = append(samples, sample)
+		}
+	}
+	var earliest sql.NullTime
+	_ = svc.db.QueryRowContext(context.Background(), `SELECT MIN(recorded_at) FROM host_resource_samples`).Scan(&earliest)
+	if earliest.Valid {
+		value := earliest.Time
+		return samples, &value
+	}
+	return samples, nil
+}
+
+func databaseSize(path string) int64 {
+	if path == "" || path == ":memory:" {
+		return 0
+	}
+	var size int64
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		info, err := os.Stat(filepath.Clean(path + suffix))
+		if err == nil {
+			size += info.Size()
+		}
+	}
+	return size
+}

--- a/internal/management/jobs.go
+++ b/internal/management/jobs.go
@@ -3,119 +3,439 @@ package management
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/actions/scaleset"
+
+	"github.com/boring-design/elastic-fruit-runner/internal/backend"
 	sqlcdb "github.com/boring-design/elastic-fruit-runner/internal/management/sqlc"
 )
 
-// JobRecord represents a single job execution.
 type JobRecord struct {
-	ID            string
-	RunnerName    string
-	RunnerSetName string
-	Result        string
-	StartedAt     time.Time
-	CompletedAt   *time.Time
+	ID                 string
+	RunnerName         string
+	RunnerSetName      string
+	Result             string
+	StartedAt          time.Time
+	CompletedAt        *time.Time
+	Owner              string
+	Repository         string
+	WorkflowRef        string
+	DisplayName        string
+	WorkflowRunID      int64
+	EventName          string
+	Labels             []string
+	QueuedAt           *time.Time
+	ScaleSetAssignedAt *time.Time
+	RunnerAssignedAt   *time.Time
+	Backend            string
 }
 
-// JobStore persists job lifecycle events in SQLite.
+type JobFilter struct {
+	Status     string
+	RunnerSet  string
+	Repository string
+	Workflow   string
+	From       *time.Time
+	To         *time.Time
+	Cursor     int
+	PageSize   int
+}
+
+type JobPage struct {
+	Records    []JobRecord
+	NextCursor string
+}
+
+type JobLog struct {
+	Sequence   int64
+	RecordedAt time.Time
+	Text       string
+}
+
+type ResourceSample = backend.ResourceSample
+
+type captureState struct {
+	cancel  context.CancelFunc
+	done    chan struct{}
+	logSize int
+}
+
 type JobStore struct {
+	db      *sql.DB
 	queries *sqlcdb.Queries
+
+	captureMu sync.Mutex
+	captures  map[string]*captureState
 }
 
-// NewJobStore creates a SQLite-backed job store.
 func NewJobStore(db *sql.DB) *JobStore {
 	return &JobStore{
-		queries: sqlcdb.New(db),
+		db:       db,
+		queries:  sqlcdb.New(db),
+		captures: make(map[string]*captureState),
 	}
 }
 
-// knownJobResults is the set of valid result strings from the GitHub Scale Set API.
 var knownJobResults = map[string]struct{}{
 	"succeeded": {},
 	"failed":    {},
 	"canceled":  {},
 }
 
-// RecordJobStarted inserts a new job with result "running".
-func (s *JobStore) RecordJobStarted(setName, jobID, runnerName string) {
+func (s *JobStore) RecordJobMessageStarted(setName, backendName string, diagnostics backend.Diagnostics, job *scaleset.JobStarted) {
 	ctx := context.Background()
-	err := s.queries.InsertJob(ctx, sqlcdb.InsertJobParams{
-		ID:            jobID,
-		RunnerName:    runnerName,
-		RunnerSetName: setName,
-		Result:        "running",
-		StartedAt:     time.Now(),
-	})
+	labels, _ := json.Marshal(job.RequestLabels)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO jobs (
+			id, runner_name, runner_set_name, result, started_at, owner, repository,
+			workflow_ref, display_name, workflow_run_id, event_name, labels_json,
+			queued_at, scale_set_assigned_at, runner_assigned_at, backend
+		) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			runner_name = excluded.runner_name,
+			runner_set_name = excluded.runner_set_name,
+			result = 'running',
+			owner = excluded.owner,
+			repository = excluded.repository,
+			workflow_ref = excluded.workflow_ref,
+			display_name = excluded.display_name,
+			workflow_run_id = excluded.workflow_run_id,
+			event_name = excluded.event_name,
+			labels_json = excluded.labels_json,
+			queued_at = excluded.queued_at,
+			scale_set_assigned_at = excluded.scale_set_assigned_at,
+			runner_assigned_at = excluded.runner_assigned_at,
+			backend = excluded.backend`,
+		job.JobID,
+		job.RunnerName,
+		setName,
+		time.Now(),
+		job.OwnerName,
+		job.RepositoryName,
+		job.JobWorkflowRef,
+		job.JobDisplayName,
+		job.WorkflowRunID,
+		job.EventName,
+		string(labels),
+		nullableTime(job.QueueTime),
+		nullableTime(job.ScaleSetAssignTime),
+		nullableTime(job.RunnerAssignTime),
+		backendName,
+	)
 	if err != nil {
-		slog.Error("failed to record job started", "job_id", jobID, "err", err)
+		slog.Error("failed to record job started", "job_id", job.JobID, "err", err)
+		return
+	}
+	if diagnostics != nil {
+		s.startCapture(job.JobID, job.RunnerName, diagnostics)
 	}
 }
 
-// RecordJobCompleted finds an existing job by ID and updates its result.
-// If the job does not exist, inserts a completed-only record.
-func (s *JobStore) RecordJobCompleted(jobID, result string) {
-	if _, ok := knownJobResults[result]; !ok {
-		slog.Error("unexpected job result from scale-set API, refusing to record invalid state", "job_id", jobID, "result", result)
+func (s *JobStore) RecordJobMessageCompleted(job *scaleset.JobCompleted) {
+	if _, ok := knownJobResults[job.Result]; !ok {
+		slog.Error("unexpected job result from scale set API", "job_id", job.JobID, "result", job.Result)
 		return
 	}
 
-	ctx := context.Background()
+	s.stopCapture(job.JobID)
 	now := time.Now()
-
-	res, err := s.queries.UpdateJobCompleted(ctx, sqlcdb.UpdateJobCompletedParams{
-		Result:      result,
+	if !job.FinishTime.IsZero() {
+		now = job.FinishTime
+	}
+	res, err := s.queries.UpdateJobCompleted(context.Background(), sqlcdb.UpdateJobCompletedParams{
+		Result:      job.Result,
 		CompletedAt: sql.NullTime{Time: now, Valid: true},
-		ID:          jobID,
+		ID:          job.JobID,
 	})
 	if err != nil {
-		slog.Error("failed to update job completed", "job_id", jobID, "err", err)
+		slog.Error("failed to update job completed", "job_id", job.JobID, "err", err)
 		return
 	}
-
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
-		slog.Error("failed to check rows affected", "job_id", jobID, "err", err)
+		slog.Error("failed to check completed job update", "job_id", job.JobID, "err", err)
 		return
 	}
-
 	if rowsAffected == 0 {
-		// Job was never recorded (e.g. daemon restarted). Insert a completed-only record.
-		err = s.queries.InsertCompletedJob(ctx, sqlcdb.InsertCompletedJobParams{
-			ID:          jobID,
-			Result:      result,
+		err = s.queries.InsertCompletedJob(context.Background(), sqlcdb.InsertCompletedJobParams{
+			ID:          job.JobID,
+			Result:      job.Result,
 			StartedAt:   now,
 			CompletedAt: sql.NullTime{Time: now, Valid: true},
 		})
 		if err != nil {
-			slog.Error("failed to insert completed-only job record", "job_id", jobID, "err", err)
+			slog.Error("failed to insert completed job", "job_id", job.JobID, "err", err)
 		}
 	}
 }
 
-// Snapshot returns recent job records, most-recent-first.
-func (s *JobStore) Snapshot() []JobRecord {
-	ctx := context.Background()
-	rows, err := s.queries.ListRecentJobs(ctx, 200)
+func (s *JobStore) RecordJobStarted(setName, jobID, runnerName string) {
+	s.RecordJobMessageStarted(setName, "", nil, &scaleset.JobStarted{
+		RunnerName:     runnerName,
+		JobMessageBase: scaleset.JobMessageBase{JobID: jobID},
+	})
+}
+
+func (s *JobStore) RecordJobCompleted(jobID, result string) {
+	s.RecordJobMessageCompleted(&scaleset.JobCompleted{
+		Result:         result,
+		JobMessageBase: scaleset.JobMessageBase{JobID: jobID},
+	})
+}
+
+func (s *JobStore) startCapture(jobID, runnerName string, diagnostics backend.Diagnostics) {
+	ctx, cancel := context.WithCancel(context.Background())
+	state := &captureState{cancel: cancel, done: make(chan struct{})}
+	s.captureMu.Lock()
+	s.captures[jobID] = state
+	s.captureMu.Unlock()
+
+	go func() {
+		defer close(state.done)
+		logTicker := time.NewTicker(2 * time.Second)
+		resourceTicker := time.NewTicker(5 * time.Second)
+		defer logTicker.Stop()
+		defer resourceTicker.Stop()
+		s.captureResource(ctx, jobID, runnerName, diagnostics)
+		for {
+			select {
+			case <-ctx.Done():
+				finalCtx, finalCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				s.captureLogs(finalCtx, jobID, runnerName, diagnostics, state)
+				s.captureResource(finalCtx, jobID, runnerName, diagnostics)
+				finalCancel()
+				return
+			case <-logTicker.C:
+				s.captureLogs(ctx, jobID, runnerName, diagnostics, state)
+			case <-resourceTicker.C:
+				s.captureResource(ctx, jobID, runnerName, diagnostics)
+			}
+		}
+	}()
+}
+
+func (s *JobStore) stopCapture(jobID string) {
+	s.captureMu.Lock()
+	state := s.captures[jobID]
+	delete(s.captures, jobID)
+	s.captureMu.Unlock()
+	if state != nil {
+		state.cancel()
+		select {
+		case <-state.done:
+		case <-time.After(6 * time.Second):
+		}
+	}
+}
+
+func (s *JobStore) captureLogs(ctx context.Context, jobID, runnerName string, diagnostics backend.Diagnostics, state *captureState) {
+	text, err := diagnostics.ReadLogs(ctx, runnerName)
+	if err != nil || len(text) <= state.logSize {
+		return
+	}
+	added := text[state.logSize:]
+	state.logSize = len(text)
+	if len(added) > 1024*1024 {
+		added = added[len(added)-1024*1024:]
+	}
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO job_logs (job_id, recorded_at, text) VALUES (?, ?, ?)`, jobID, time.Now(), added); err != nil {
+		slog.Warn("failed to record job logs", "job_id", jobID, "err", err)
+	}
+}
+
+func (s *JobStore) captureResource(ctx context.Context, jobID, runnerName string, diagnostics backend.Diagnostics) {
+	sample, err := diagnostics.ReadResource(ctx, runnerName)
 	if err != nil {
-		slog.Error("failed to list recent jobs", "err", err)
+		return
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO job_resource_samples (
+			job_id, recorded_at, source, accuracy, cpu_percent, memory_used_bytes,
+			memory_available_bytes, disk_used_bytes, disk_available_bytes,
+			disk_read_bytes, disk_write_bytes, network_receive_bytes, network_send_bytes
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		jobID, sample.RecordedAt, sample.Source, sample.Accuracy, sample.CPUPercent,
+		sample.MemoryUsedBytes, sample.MemoryAvailableBytes, sample.DiskUsedBytes,
+		sample.DiskAvailableBytes, sample.DiskReadBytes, sample.DiskWriteBytes,
+		sample.NetworkReceiveBytes, sample.NetworkSendBytes,
+	)
+	if err != nil {
+		slog.Warn("failed to record job resource data", "job_id", jobID, "err", err)
+	}
+}
+
+func (s *JobStore) Snapshot() []JobRecord {
+	page := s.List(JobFilter{PageSize: 200})
+	return page.Records
+}
+
+func (s *JobStore) List(filter JobFilter) JobPage {
+	rows, err := s.db.QueryContext(context.Background(), `
+		SELECT id, runner_name, runner_set_name, result, started_at, completed_at,
+			owner, repository, workflow_ref, display_name, workflow_run_id, event_name,
+			labels_json, queued_at, scale_set_assigned_at, runner_assigned_at, backend
+		FROM jobs ORDER BY started_at DESC LIMIT 2000`)
+	if err != nil {
+		slog.Error("failed to list jobs", "err", err)
+		return JobPage{}
+	}
+	defer rows.Close()
+
+	var records []JobRecord
+	for rows.Next() {
+		record, scanErr := scanJob(rows)
+		if scanErr != nil {
+			slog.Error("failed to read job", "err", scanErr)
+			continue
+		}
+		if matchesJob(record, filter) {
+			records = append(records, record)
+		}
+	}
+	start := max(filter.Cursor, 0)
+	if start >= len(records) {
+		return JobPage{}
+	}
+	pageSize := filter.PageSize
+	if pageSize <= 0 || pageSize > 200 {
+		pageSize = 50
+	}
+	end := min(start+pageSize, len(records))
+	page := JobPage{Records: records[start:end]}
+	if end < len(records) {
+		page.NextCursor = strconv.Itoa(end)
+	}
+	return page
+}
+
+func (s *JobStore) Get(jobID string) (*JobRecord, error) {
+	row := s.db.QueryRowContext(context.Background(), `
+		SELECT id, runner_name, runner_set_name, result, started_at, completed_at,
+			owner, repository, workflow_ref, display_name, workflow_run_id, event_name,
+			labels_json, queued_at, scale_set_assigned_at, runner_assigned_at, backend
+		FROM jobs WHERE id = ?`, jobID)
+	record, err := scanJob(row)
+	if err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanJob(row rowScanner) (JobRecord, error) {
+	var record JobRecord
+	var completedAt, queuedAt, scaleSetAssignedAt, runnerAssignedAt sql.NullTime
+	var labels string
+	err := row.Scan(
+		&record.ID, &record.RunnerName, &record.RunnerSetName, &record.Result,
+		&record.StartedAt, &completedAt, &record.Owner, &record.Repository,
+		&record.WorkflowRef, &record.DisplayName, &record.WorkflowRunID,
+		&record.EventName, &labels, &queuedAt, &scaleSetAssignedAt,
+		&runnerAssignedAt, &record.Backend,
+	)
+	if err != nil {
+		return JobRecord{}, err
+	}
+	_ = json.Unmarshal([]byte(labels), &record.Labels)
+	record.CompletedAt = timePointer(completedAt)
+	record.QueuedAt = timePointer(queuedAt)
+	record.ScaleSetAssignedAt = timePointer(scaleSetAssignedAt)
+	record.RunnerAssignedAt = timePointer(runnerAssignedAt)
+	return record, nil
+}
+
+func matchesJob(record JobRecord, filter JobFilter) bool {
+	if filter.Status != "" && !strings.EqualFold(record.Result, filter.Status) {
+		return false
+	}
+	if filter.RunnerSet != "" && record.RunnerSetName != filter.RunnerSet {
+		return false
+	}
+	repository := record.Owner + "/" + record.Repository
+	if filter.Repository != "" && !strings.Contains(strings.ToLower(repository), strings.ToLower(filter.Repository)) {
+		return false
+	}
+	if filter.Workflow != "" && !strings.Contains(strings.ToLower(record.WorkflowRef), strings.ToLower(filter.Workflow)) {
+		return false
+	}
+	if filter.From != nil && record.StartedAt.Before(*filter.From) {
+		return false
+	}
+	if filter.To != nil && record.StartedAt.After(*filter.To) {
+		return false
+	}
+	return true
+}
+
+func (s *JobStore) Logs(jobID string, after int64, pageSize int) (logs []JobLog, nextSequence int64) {
+	if pageSize <= 0 || pageSize > 500 {
+		pageSize = 200
+	}
+	rows, err := s.db.QueryContext(context.Background(), `
+		SELECT sequence, recorded_at, text FROM job_logs
+		WHERE job_id = ? AND sequence > ? ORDER BY sequence LIMIT ?`,
+		jobID, after, pageSize,
+	)
+	if err != nil {
+		return nil, after
+	}
+	defer rows.Close()
+	next := after
+	for rows.Next() {
+		var line JobLog
+		if err := rows.Scan(&line.Sequence, &line.RecordedAt, &line.Text); err == nil {
+			logs = append(logs, line)
+			next = line.Sequence
+		}
+	}
+	return logs, next
+}
+
+func (s *JobStore) Samples(jobID string) []ResourceSample {
+	rows, err := s.db.QueryContext(context.Background(), `
+		SELECT recorded_at, source, accuracy, cpu_percent, memory_used_bytes,
+			memory_available_bytes, disk_used_bytes, disk_available_bytes,
+			disk_read_bytes, disk_write_bytes, network_receive_bytes, network_send_bytes
+		FROM job_resource_samples WHERE job_id = ? ORDER BY recorded_at`, jobID)
+	if err != nil {
 		return nil
 	}
-
-	records := make([]JobRecord, len(rows))
-	for i, row := range rows {
-		records[i] = JobRecord{
-			ID:            row.ID,
-			RunnerName:    row.RunnerName,
-			RunnerSetName: row.RunnerSetName,
-			Result:        row.Result,
-			StartedAt:     row.StartedAt,
-		}
-		if row.CompletedAt.Valid {
-			t := row.CompletedAt.Time
-			records[i].CompletedAt = &t
+	defer rows.Close()
+	var samples []ResourceSample
+	for rows.Next() {
+		var sample ResourceSample
+		if err := rows.Scan(
+			&sample.RecordedAt, &sample.Source, &sample.Accuracy, &sample.CPUPercent,
+			&sample.MemoryUsedBytes, &sample.MemoryAvailableBytes, &sample.DiskUsedBytes,
+			&sample.DiskAvailableBytes, &sample.DiskReadBytes, &sample.DiskWriteBytes,
+			&sample.NetworkReceiveBytes, &sample.NetworkSendBytes,
+		); err == nil {
+			samples = append(samples, sample)
 		}
 	}
-	return records
+	return samples
+}
+
+func nullableTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value
+}
+
+func timePointer(value sql.NullTime) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	result := value.Time
+	return &result
 }

--- a/internal/management/migrations/002_add_history.sql
+++ b/internal/management/migrations/002_add_history.sql
@@ -1,0 +1,62 @@
+-- +goose Up
+ALTER TABLE jobs ADD COLUMN owner TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN repository TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN workflow_ref TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN display_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN workflow_run_id INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN event_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN labels_json TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE jobs ADD COLUMN queued_at DATETIME;
+ALTER TABLE jobs ADD COLUMN scale_set_assigned_at DATETIME;
+ALTER TABLE jobs ADD COLUMN runner_assigned_at DATETIME;
+ALTER TABLE jobs ADD COLUMN backend TEXT NOT NULL DEFAULT '';
+
+CREATE TABLE job_logs (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    recorded_at DATETIME NOT NULL,
+    text TEXT NOT NULL
+);
+
+CREATE INDEX idx_job_logs_job_sequence ON job_logs (job_id, sequence);
+
+CREATE TABLE job_resource_samples (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    recorded_at DATETIME NOT NULL,
+    source TEXT NOT NULL,
+    accuracy TEXT NOT NULL,
+    cpu_percent REAL NOT NULL DEFAULT 0,
+    memory_used_bytes INTEGER NOT NULL DEFAULT 0,
+    memory_available_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_used_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_available_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_read_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_write_bytes INTEGER NOT NULL DEFAULT 0,
+    network_receive_bytes INTEGER NOT NULL DEFAULT 0,
+    network_send_bytes INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_job_samples_job_time ON job_resource_samples (job_id, recorded_at);
+
+CREATE TABLE host_resource_samples (
+    recorded_at DATETIME NOT NULL,
+    interval_seconds INTEGER NOT NULL,
+    cpu_percent REAL NOT NULL DEFAULT 0,
+    memory_used_bytes INTEGER NOT NULL DEFAULT 0,
+    memory_available_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_used_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_available_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_read_bytes INTEGER NOT NULL DEFAULT 0,
+    disk_write_bytes INTEGER NOT NULL DEFAULT 0,
+    load_one REAL NOT NULL DEFAULT 0,
+    temperature_celsius REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (recorded_at, interval_seconds)
+);
+
+CREATE INDEX idx_host_samples_time ON host_resource_samples (recorded_at);
+
+-- +goose Down
+DROP TABLE host_resource_samples;
+DROP TABLE job_resource_samples;
+DROP TABLE job_logs;

--- a/internal/management/service.go
+++ b/internal/management/service.go
@@ -30,10 +30,12 @@ type RunnerSetView struct {
 
 // Service manages all ScaleSetControllers and provides aggregated read access.
 type Service struct {
-	cfg         *config.Config
-	controllers []*controller.ScaleSetController
-	jobs        *JobStore
-	db          *sql.DB
+	cfg             *config.Config
+	controllers     []*controller.ScaleSetController
+	jobs            *JobStore
+	db              *sql.DB
+	databasePath    string
+	hostSampleCount int
 
 	wg sync.WaitGroup
 }
@@ -42,15 +44,20 @@ type Service struct {
 // It initializes the SQLite database, runs migrations, creates GitHub clients,
 // backends, and controllers but does not start them.
 func New(cfg *config.Config) (*Service, error) {
-	db, err := openJobsDB(cfg.DBPath)
+	databasePath, err := cfg.DatabasePath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve jobs database path: %w", err)
+	}
+	db, err := openJobsDB(databasePath)
 	if err != nil {
 		return nil, fmt.Errorf("open jobs database: %w", err)
 	}
 
 	svc := &Service{
-		cfg:  cfg,
-		db:   db,
-		jobs: NewJobStore(db),
+		cfg:          cfg,
+		db:           db,
+		jobs:         NewJobStore(db),
+		databasePath: databasePath,
 	}
 
 	for i := range cfg.Orgs {
@@ -122,6 +129,22 @@ func (svc *Service) ListRunnerSets() []RunnerSetView {
 // ListJobRecords returns job history, most-recent-first.
 func (svc *Service) ListJobRecords() []JobRecord {
 	return svc.jobs.Snapshot()
+}
+
+func (svc *Service) FindJobRecords(filter JobFilter) JobPage {
+	return svc.jobs.List(filter)
+}
+
+func (svc *Service) GetJobRecord(jobID string) (*JobRecord, error) {
+	return svc.jobs.Get(jobID)
+}
+
+func (svc *Service) GetJobLogs(jobID string, after int64, pageSize int) (logs []JobLog, nextSequence int64) {
+	return svc.jobs.Logs(jobID, after, pageSize)
+}
+
+func (svc *Service) GetJobSamples(jobID string) []ResourceSample {
+	return svc.jobs.Samples(jobID)
 }
 
 func (svc *Service) runController(ctx context.Context, ctrl *controller.ScaleSetController) {

--- a/internal/tart/manager.go
+++ b/internal/tart/manager.go
@@ -159,6 +159,12 @@ func (m *Manager) IPAddress(ctx context.Context, name string) (string, error) {
 // The default Cirrus Labs macos base images use admin:admin credentials.
 // It waits for SSH to become reachable with exponential backoff before executing.
 func (m *Manager) Exec(ctx context.Context, name string, args ...string) error {
+	_, err := m.ExecOutput(ctx, name, args...)
+	return err
+}
+
+// ExecOutput runs a command inside the VM and returns its output.
+func (m *Manager) ExecOutput(ctx context.Context, name string, args ...string) (string, error) {
 	ctx, span := tracer.Start(ctx, "tart.ssh_exec",
 		trace.WithAttributes(attribute.String("vm.name", name)),
 	)
@@ -168,13 +174,13 @@ func (m *Manager) Exec(ctx context.Context, name string, args ...string) error {
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return err
+		return "", err
 	}
 
 	if err := m.waitForSSH(ctx, name, ip); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return err
+		return "", err
 	}
 
 	sshArgs := m.buildSSHArgs(ip, args...)
@@ -187,9 +193,9 @@ func (m *Manager) Exec(ctx context.Context, name string, args ...string) error {
 		err = fmt.Errorf("ssh exec %s (%s): %w\n%s", name, ip, err, buf.Bytes())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return err
+		return "", err
 	}
-	return nil
+	return buf.String(), nil
 }
 
 // waitForSSH verifies the actual SSH transport used by Exec instead of only

--- a/internal/vitals/collector.go
+++ b/internal/vitals/collector.go
@@ -6,17 +6,28 @@ import (
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/shirou/gopsutil/v4/load"
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/shirou/gopsutil/v4/sensors"
 )
 
 // Collect gathers current host metrics from the OS using gopsutil.
 func Collect() Vitals {
+	memoryPercent, memoryUsed, memoryAvailable, swapUsed := collectMemory()
+	diskPercent, diskUsed, diskAvailable, diskRead, diskWrite := collectDisk()
 	return Vitals{
-		CPUUsagePercent:    collectCPU(),
-		MemoryUsagePercent: collectMemory(),
-		DiskUsagePercent:   collectDisk(),
-		TemperatureCelsius: collectTemperature(),
+		CPUUsagePercent:      collectCPU(),
+		MemoryUsagePercent:   memoryPercent,
+		MemoryUsedBytes:      memoryUsed,
+		MemoryAvailableBytes: memoryAvailable,
+		SwapUsedBytes:        swapUsed,
+		DiskUsagePercent:     diskPercent,
+		DiskUsedBytes:        diskUsed,
+		DiskAvailableBytes:   diskAvailable,
+		DiskReadBytes:        diskRead,
+		DiskWriteBytes:       diskWrite,
+		LoadOne:              collectLoad(),
+		TemperatureCelsius:   collectTemperature(),
 	}
 }
 
@@ -29,22 +40,42 @@ func collectCPU() float32 {
 	return float32(percentages[0])
 }
 
-func collectMemory() float32 {
+func collectMemory() (usagePercent float32, usedBytes, availableBytes, swapUsedBytes int64) {
 	v, err := mem.VirtualMemory()
 	if err != nil {
 		slog.Debug("failed to collect memory usage", "err", err)
-		return 0
+		return 0, 0, 0, 0
 	}
-	return float32(v.UsedPercent)
+	swap, _ := mem.SwapMemory()
+	var swapUsed uint64
+	if swap != nil {
+		swapUsed = swap.Used
+	}
+	return float32(v.UsedPercent), int64(v.Used), int64(v.Available), int64(swapUsed)
 }
 
-func collectDisk() float32 {
+func collectDisk() (usagePercent float32, usedBytes, availableBytes, readBytes, writeBytes int64) {
 	usage, err := disk.Usage("/")
 	if err != nil {
 		slog.Debug("failed to collect disk usage", "err", err)
+		return 0, 0, 0, 0, 0
+	}
+	var readTotal, writeTotal uint64
+	if counters, counterErr := disk.IOCounters(); counterErr == nil {
+		for _, counter := range counters {
+			readTotal += counter.ReadBytes
+			writeTotal += counter.WriteBytes
+		}
+	}
+	return float32(usage.UsedPercent), int64(usage.Used), int64(usage.Free), int64(readTotal), int64(writeTotal)
+}
+
+func collectLoad() float64 {
+	average, err := load.Avg()
+	if err != nil {
 		return 0
 	}
-	return float32(usage.UsedPercent)
+	return average.Load1
 }
 
 func collectTemperature() float32 {

--- a/internal/vitals/service.go
+++ b/internal/vitals/service.go
@@ -11,8 +11,9 @@ import (
 type Service struct {
 	startedAt time.Time
 
-	mu      sync.RWMutex
-	current Vitals
+	mu       sync.RWMutex
+	current  Vitals
+	onUpdate func(Vitals)
 }
 
 // New creates a Service that records the given start time.
@@ -29,8 +30,19 @@ func (s *Service) Start(ctx context.Context, interval time.Duration) {
 	RunCollector(ctx, interval, func(v Vitals) {
 		s.mu.Lock()
 		s.current = v
+		onUpdate := s.onUpdate
 		s.mu.Unlock()
+		if onUpdate != nil {
+			onUpdate(v)
+		}
 	})
+}
+
+// SetOnUpdate sets the function called after each resource sample.
+func (s *Service) SetOnUpdate(onUpdate func(Vitals)) {
+	s.mu.Lock()
+	s.onUpdate = onUpdate
+	s.mu.Unlock()
 }
 
 // StartedAt returns when the daemon process started.

--- a/internal/vitals/types.go
+++ b/internal/vitals/types.go
@@ -7,10 +7,18 @@ import (
 
 // Vitals holds a point-in-time snapshot of host resource metrics.
 type Vitals struct {
-	CPUUsagePercent    float32
-	MemoryUsagePercent float32
-	DiskUsagePercent   float32
-	TemperatureCelsius float32
+	CPUUsagePercent      float32
+	MemoryUsagePercent   float32
+	DiskUsagePercent     float32
+	TemperatureCelsius   float32
+	LoadOne              float64
+	MemoryUsedBytes      int64
+	MemoryAvailableBytes int64
+	SwapUsedBytes        int64
+	DiskUsedBytes        int64
+	DiskAvailableBytes   int64
+	DiskReadBytes        int64
+	DiskWriteBytes       int64
 }
 
 // CollectFunc is the signature for a function that collects host metrics.

--- a/proto/controlplane/v1/controlplane.proto
+++ b/proto/controlplane/v1/controlplane.proto
@@ -29,6 +29,14 @@ service ControlPlaneService {
   // across all runner sets, ordered most-recent-first.
   rpc ListJobRecords(ListJobRecordsRequest) returns (ListJobRecordsResponse);
 
+  rpc GetJobDetail(GetJobDetailRequest) returns (GetJobDetailResponse);
+
+  rpc GetJobLogs(GetJobLogsRequest) returns (GetJobLogsResponse);
+
+  rpc GetJobResourceSamples(GetJobResourceSamplesRequest) returns (GetJobResourceSamplesResponse);
+
+  rpc GetHostResourceSamples(GetHostResourceSamplesRequest) returns (GetHostResourceSamplesResponse);
+
   // GetMachineVitals returns a point-in-time snapshot of host-level
   // resource metrics (CPU, memory, disk, temperature).
   rpc GetMachineVitals(GetMachineVitalsRequest) returns (GetMachineVitalsResponse);
@@ -178,10 +186,20 @@ message Runner {
 // ListJobRecords
 // ---------------------------------------------------------------------------
 
-message ListJobRecordsRequest {}
+message ListJobRecordsRequest {
+  string status = 1;
+  string runner_set = 2;
+  string repository = 3;
+  string workflow = 4;
+  optional google.protobuf.Timestamp from = 5;
+  optional google.protobuf.Timestamp to = 6;
+  string cursor = 7;
+  int32 page_size = 8;
+}
 
 message ListJobRecordsResponse {
   repeated JobRecord job_records = 1;
+  string next_cursor = 2;
 }
 
 enum JobResult {
@@ -205,6 +223,84 @@ message JobRecord {
   google.protobuf.Timestamp started_at = 5;
   // When the job finished. Absent if still running.
   optional google.protobuf.Timestamp completed_at = 6;
+  string owner = 7;
+  string repository = 8;
+  string workflow_ref = 9;
+  string display_name = 10;
+  int64 workflow_run_id = 11;
+  string event_name = 12;
+  repeated string labels = 13;
+  optional google.protobuf.Timestamp queued_at = 14;
+  optional google.protobuf.Timestamp scale_set_assigned_at = 15;
+  optional google.protobuf.Timestamp runner_assigned_at = 16;
+  Backend backend = 17;
+  string actions_url = 18;
+}
+
+message GetJobDetailRequest {
+  string id = 1;
+}
+
+message GetJobDetailResponse {
+  JobRecord job = 1;
+}
+
+message GetJobLogsRequest {
+  string job_id = 1;
+  int64 after_sequence = 2;
+  int32 page_size = 3;
+}
+
+message JobLogLine {
+  int64 sequence = 1;
+  google.protobuf.Timestamp recorded_at = 2;
+  string text = 3;
+}
+
+message GetJobLogsResponse {
+  repeated JobLogLine lines = 1;
+  int64 next_sequence = 2;
+}
+
+enum ResourceAccuracy {
+  RESOURCE_ACCURACY_UNSPECIFIED = 0;
+  RESOURCE_ACCURACY_EXACT = 1;
+  RESOURCE_ACCURACY_ESTIMATE = 2;
+}
+
+message ResourceSample {
+  google.protobuf.Timestamp recorded_at = 1;
+  string source = 2;
+  ResourceAccuracy accuracy = 3;
+  double cpu_percent = 4;
+  int64 memory_used_bytes = 5;
+  int64 memory_available_bytes = 6;
+  int64 disk_used_bytes = 7;
+  int64 disk_available_bytes = 8;
+  int64 disk_read_bytes = 9;
+  int64 disk_write_bytes = 10;
+  int64 network_receive_bytes = 11;
+  int64 network_send_bytes = 12;
+  double load_one = 13;
+  double temperature_celsius = 14;
+}
+
+message GetJobResourceSamplesRequest {
+  string job_id = 1;
+}
+
+message GetJobResourceSamplesResponse {
+  repeated ResourceSample samples = 1;
+}
+
+message GetHostResourceSamplesRequest {
+  optional google.protobuf.Timestamp from = 1;
+  optional google.protobuf.Timestamp to = 2;
+}
+
+message GetHostResourceSamplesResponse {
+  repeated ResourceSample samples = 1;
+  optional google.protobuf.Timestamp earliest_at = 2;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The console shows current state but cannot explain completed jobs or host resource changes over time.

## Solution

Persist job metadata, logs, job resource samples, and host resource history in SQLite, then expose them through the existing Connect RPC service and console.

## Major Changes

- Job history
  - Add repository, workflow, lifecycle, backend, labels, GitHub Actions links, filters, detail view, and cursor based logs
- Resource history
  - Collect Docker data as exact backend samples and mark Tart allocation data as estimates
  - Store host samples every five seconds and one minute rollups for thirty days
- Retention
  - Apply the ten GB limit with cleanup of old completed jobs while preserving running jobs
- Console
  - Add job filters, job detail, logs, resource charts, and System host history

## Validation

- `make check`
- Dashboard build and lint
- Existing Go tests

Closes #86
Tracked by #84