### PR TITLE
feat(console): add config editing and validation

### DIFF
--- a/cmd/elastic-fruit-runner/main.go
+++ b/cmd/elastic-fruit-runner/main.go
@@ -37,18 +37,47 @@ func run() error {
 	return runDaemon()
 }
 
+//nolint:gocyclo // Startup handles normal, recovery, and config mode in one ordered flow.
 func runDaemon() error {
-	cfg, err := config.Load()
+	configPath := config.FindConfigPath(os.Args[1:])
+	databasePath, err := config.DefaultDatabasePath()
 	if err != nil {
-		return fmt.Errorf("load configuration: %w", err)
-	}
-
-	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("invalid configuration: %w", err)
-	}
-
-	if err := configureLogging(cfg); err != nil {
 		return err
+	}
+	revisionPath := databasePath
+	cfg, configErr := config.Load()
+	if configErr == nil {
+		if err := cfg.Validate(); err != nil {
+			configErr = err
+		}
+	}
+	if cfg != nil {
+		if path, pathErr := cfg.DatabasePath(); pathErr == nil {
+			databasePath = path
+		}
+	}
+	if configErr != nil {
+		recovered, recoverErr := configstate.LoadLastActive(revisionPath)
+		if recoverErr == nil {
+			result := config.ValidateYAML(recovered)
+			if len(result.Errors) == 0 {
+				cfg = result.Config
+				cfg.FilePath = configPath
+				cfg.LoadedYAML = recovered
+				slog.Warn("disk config is invalid, using last active config", "path", configPath, "err", configErr)
+			} else {
+				cfg = nil
+			}
+		} else {
+			cfg = nil
+		}
+	}
+	if cfg != nil {
+		if err := configureLogging(cfg); err != nil {
+			return err
+		}
+	} else {
+		slog.Warn("starting in config mode", "path", configPath, "err", configErr)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -67,19 +96,18 @@ func runDaemon() error {
 
 	vitalsService := vitals.New(startedAt)
 
-	managementService, err := management.New(cfg)
-	if err != nil {
-		return fmt.Errorf("initialize scale set controller management service: %w", err)
+	var managementService *management.Service
+	if cfg != nil {
+		managementService, err = management.New(cfg)
+		if err != nil {
+			return fmt.Errorf("initialize scale set controller management service: %w", err)
+		}
+		defer managementService.Close()
+		vitalsService.SetOnUpdate(managementService.RecordHostVitals)
+		managementService.Start(ctx)
 	}
-	defer managementService.Close()
-	vitalsService.SetOnUpdate(managementService.RecordHostVitals)
 	go vitalsService.Start(ctx, 5*time.Second)
-	managementService.Start(ctx)
 
-	databasePath, err := cfg.DatabasePath()
-	if err != nil {
-		return fmt.Errorf("resolve console database path: %w", err)
-	}
 	authService, err := auth.Open(databasePath)
 	if err != nil {
 		return fmt.Errorf("initialize console auth: %w", err)
@@ -87,18 +115,31 @@ func runDaemon() error {
 	defer authService.Close()
 	logSetupCode(authService)
 
-	configStateService := configstate.New(cfg, startedAt)
+	var configStateService *configstate.Service
+	if cfg != nil {
+		configStateService = configstate.New(cfg, startedAt, revisionPath)
+	} else {
+		configStateService = configstate.NewForConfigMode(configPath, revisionPath, startedAt)
+	}
+	defer configStateService.Close()
 	go configStateService.Start(ctx, 2*time.Second)
 
-	apiAddr := cfg.APIAddr
+	apiAddr := ""
+	cors := config.CORSConfig{}
+	idleTimeout := 15 * time.Minute
+	if cfg != nil {
+		apiAddr = cfg.APIAddr
+		cors = cfg.CORS
+		idleTimeout = cfg.IdleTimeout
+	}
 	if apiAddr == "" {
 		apiAddr = ":8080"
 	}
 	apiServer := api.NewServer(
 		managementService,
 		vitalsService,
-		cfg.IdleTimeout,
-		cfg.CORS,
+		idleTimeout,
+		cors,
 		api.Dependencies{
 			Auth:         authService,
 			ConfigState:  configStateService,
@@ -129,10 +170,17 @@ func runDaemon() error {
 	}()
 
 	done := make(chan struct{})
-	go func() {
-		managementService.Wait()
-		close(done)
-	}()
+	if managementService != nil {
+		go func() {
+			managementService.Wait()
+			close(done)
+		}()
+	} else {
+		go func() {
+			<-ctx.Done()
+			close(done)
+		}()
+	}
 
 	select {
 	case err := <-listenErr:

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	APIAddr     string        `yaml:"api_addr"`
 	CORS        CORSConfig    `yaml:"cors"`
 	DBPath      string        `yaml:"db_path"`
+	LogPath     string        `yaml:"log_path"`
 	FilePath    string        `yaml:"-"`
 	LoadedHash  string        `yaml:"-"`
 	LoadedYAML  []byte        `yaml:"-"`
@@ -162,7 +163,6 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/config/load.go
+++ b/config/load.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/pflag"
@@ -83,10 +84,56 @@ func LoadWithArgs(args []string) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read loaded config %s: %w", cfg.FilePath, err)
 		}
+		validation := ValidateYAML(data)
+		if len(validation.Errors) > 0 {
+			return nil, fmt.Errorf("validate config %s: %s", cfg.FilePath, validation.Errors[0].String())
+		}
+		loadedLogLevel := cfg.LogLevel
+		cfg = validation.Config
+		cfg.LogLevel = loadedLogLevel
+		cfg.FilePath = absolutePath
 		sum := sha256.Sum256(data)
 		cfg.LoadedHash = hex.EncodeToString(sum[:])
 		cfg.LoadedYAML = data
 	}
 
 	return cfg, nil
+}
+
+// FindConfigPath returns the requested config path or the first default path.
+func FindConfigPath(args []string) string {
+	for index, arg := range args {
+		if arg == "--config" && index+1 < len(args) {
+			path, _ := filepath.Abs(args[index+1])
+			return path
+		}
+		if value, found := strings.CutPrefix(arg, "--config="); found {
+			path, _ := filepath.Abs(value)
+			return path
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths := []string{
+			filepath.Join(home, ".elastic-fruit-runner", "config.yaml"),
+			"/opt/homebrew/var/elastic-fruit-runner/config.yaml",
+			"/usr/local/var/elastic-fruit-runner/config.yaml",
+			"/etc/elastic-fruit-runner/config.yaml",
+		}
+		for _, path := range paths {
+			if _, err := os.Stat(path); err == nil {
+				return path
+			}
+		}
+		return paths[0]
+	}
+	return "/etc/elastic-fruit-runner/config.yaml"
+}
+
+// DefaultDatabasePath returns the local console database path.
+func DefaultDatabasePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home directory for database path: %w", err)
+	}
+	return filepath.Join(home, ".elastic-fruit-runner", "jobs.db"), nil
 }

--- a/config/validation.go
+++ b/config/validation.go
@@ -1,0 +1,274 @@
+package config
+
+import (
+	"bytes"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type ValidationIssue struct {
+	Path    string
+	Message string
+}
+
+func (i ValidationIssue) String() string {
+	if i.Path == "" {
+		return i.Message
+	}
+	return i.Path + ": " + i.Message
+}
+
+type ValidationResult struct {
+	Config     *Config
+	Errors     []ValidationIssue
+	Warnings   []ValidationIssue
+	Normalized string
+}
+
+type rawConfig struct {
+	Orgs        []OrgConfig   `yaml:"orgs"`
+	Repos       []RepoConfig  `yaml:"repos"`
+	IdleTimeout durationValue `yaml:"idle_timeout"`
+	LogLevel    string        `yaml:"log_level"`
+	APIAddr     string        `yaml:"api_addr"`
+	CORS        CORSConfig    `yaml:"cors"`
+	DBPath      string        `yaml:"db_path"`
+	LogPath     string        `yaml:"log_path"`
+}
+
+type durationValue time.Duration
+
+func (d *durationValue) UnmarshalYAML(node *yaml.Node) error {
+	value, err := time.ParseDuration(node.Value)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q", node.Value)
+	}
+	*d = durationValue(value)
+	return nil
+}
+
+func (d durationValue) MarshalYAML() (any, error) {
+	return time.Duration(d).String(), nil
+}
+
+func ValidateYAML(data []byte) ValidationResult {
+	var raw rawConfig
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&raw); err != nil {
+		return ValidationResult{
+			Errors: []ValidationIssue{{Path: "$", Message: err.Error()}},
+		}
+	}
+	cfg := &Config{
+		Orgs:        raw.Orgs,
+		Repos:       raw.Repos,
+		IdleTimeout: time.Duration(raw.IdleTimeout),
+		LogLevel:    raw.LogLevel,
+		APIAddr:     raw.APIAddr,
+		CORS:        raw.CORS,
+		DBPath:      raw.DBPath,
+		LogPath:     raw.LogPath,
+	}
+	if cfg.IdleTimeout == 0 {
+		cfg.IdleTimeout = 15 * time.Minute
+	}
+	if cfg.LogLevel == "" {
+		cfg.LogLevel = "info"
+	}
+	result := ValidateConfig(cfg)
+	result.Config = cfg
+	if len(result.Errors) == 0 {
+		normalized, err := yaml.Marshal(rawConfig{
+			Orgs:        cfg.Orgs,
+			Repos:       cfg.Repos,
+			IdleTimeout: durationValue(cfg.IdleTimeout),
+			LogLevel:    cfg.LogLevel,
+			APIAddr:     cfg.APIAddr,
+			CORS:        cfg.CORS,
+			DBPath:      cfg.DBPath,
+			LogPath:     cfg.LogPath,
+		})
+		if err == nil {
+			result.Normalized = string(normalized)
+		}
+	}
+	return result
+}
+
+//nolint:gocyclo // Validation keeps every field path in one clear pass.
+func ValidateConfig(cfg *Config) ValidationResult {
+	var result ValidationResult
+	addError := func(path, message string) {
+		result.Errors = append(result.Errors, ValidationIssue{Path: path, Message: message})
+	}
+	if len(cfg.Orgs) == 0 && len(cfg.Repos) == 0 {
+		addError("$", "at least one org or repo is required")
+	}
+	if cfg.IdleTimeout <= 0 {
+		addError("idle_timeout", "must be greater than 0")
+	}
+	if _, err := cfg.ParsedLogLevel(); err != nil {
+		addError("log_level", "must be debug, info, warn, or error")
+	}
+	if cfg.APIAddr != "" {
+		if _, _, err := net.SplitHostPort(cfg.APIAddr); err != nil {
+			addError("api_addr", "must be a host and port such as :8080")
+		}
+	}
+	if cfg.CORS.AllowCredentials && (cfg.CORS.AllowOrigin == "" || cfg.CORS.AllowOrigin == "*") {
+		addError("cors.allow_origin", "must be a specific origin when credentials are allowed")
+	}
+	if cfg.CORS.AllowOrigin != "" && cfg.CORS.AllowOrigin != "*" {
+		parsed, err := url.Parse(cfg.CORS.AllowOrigin)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			addError("cors.allow_origin", "must be a valid origin URL")
+		}
+	}
+	if cfg.CORS.MaxAge < 0 || cfg.CORS.MaxAge > 86400 {
+		addError("cors.max_age", "must be between 0 and 86400")
+	}
+	validateWritablePath(cfg.DBPath, "db_path", addError)
+	validateWritablePath(cfg.LogPath, "log_path", addError)
+
+	names := make(map[string]string)
+	for index := range cfg.Orgs {
+		org := &cfg.Orgs[index]
+		path := "orgs[" + strconv.Itoa(index) + "]"
+		if !validGitHubName(org.Org) {
+			addError(path+".org", "must be a valid GitHub organization name")
+		}
+		validateAuthAll(&org.Auth, path+".auth", addError)
+		if org.RunnerGroup == "" {
+			org.RunnerGroup = "Default"
+		}
+		if len(org.RunnerSets) == 0 {
+			addError(path+".runner_sets", "must contain at least one runner set")
+		}
+		for runnerIndex := range org.RunnerSets {
+			validateRunnerSetAll(&org.RunnerSets[runnerIndex], path+".runner_sets["+strconv.Itoa(runnerIndex)+"]", names, addError)
+		}
+	}
+	for index := range cfg.Repos {
+		repo := &cfg.Repos[index]
+		path := "repos[" + strconv.Itoa(index) + "]"
+		parts := strings.Split(repo.Repo, "/")
+		if len(parts) != 2 || !validGitHubName(parts[0]) || !validGitHubName(parts[1]) {
+			addError(path+".repo", "must use owner/repo format")
+		}
+		validateAuthAll(&repo.Auth, path+".auth", addError)
+		if len(repo.RunnerSets) == 0 {
+			addError(path+".runner_sets", "must contain at least one runner set")
+		}
+		for runnerIndex := range repo.RunnerSets {
+			validateRunnerSetAll(&repo.RunnerSets[runnerIndex], path+".runner_sets["+strconv.Itoa(runnerIndex)+"]", names, addError)
+		}
+	}
+	result.Warnings = append(result.Warnings, ValidationIssue{
+		Path:    "$",
+		Message: "GitHub connectivity is not checked during config validation",
+	})
+	return result
+}
+
+var githubNamePattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?$`)
+
+func validGitHubName(value string) bool {
+	return githubNamePattern.MatchString(value)
+}
+
+func validateAuthAll(auth *AuthConfig, path string, addError func(string, string)) {
+	hasToken := auth.PATToken != nil
+	hasApp := auth.GitHubApp != nil
+	if hasToken == hasApp {
+		addError(path, "configure exactly one of pat_token or github_app")
+		return
+	}
+	if hasToken {
+		if strings.TrimSpace(*auth.PATToken) == "" {
+			addError(path+".pat_token", "must not be empty")
+		}
+		return
+	}
+	app := auth.GitHubApp
+	if app.ClientID == "" {
+		addError(path+".github_app.client_id", "is required")
+	}
+	if app.InstallationID <= 0 {
+		addError(path+".github_app.installation_id", "must be greater than 0")
+	}
+	if app.PrivateKeyPath == "" {
+		addError(path+".github_app.private_key_path", "is required")
+		return
+	}
+	data, err := os.ReadFile(app.PrivateKeyPath)
+	if err != nil {
+		addError(path+".github_app.private_key_path", "cannot be read: "+err.Error())
+		return
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || !strings.Contains(block.Type, "PRIVATE KEY") {
+		addError(path+".github_app.private_key_path", "must contain a valid PEM private key")
+	}
+}
+
+func validateRunnerSetAll(rs *RunnerSetConfig, path string, names map[string]string, addError func(string, string)) {
+	if strings.TrimSpace(rs.Name) == "" {
+		addError(path+".name", "is required")
+	} else if previous, exists := names[rs.Name]; exists {
+		addError(path+".name", "must be unique and is already used at "+previous)
+	} else {
+		names[rs.Name] = path + ".name"
+	}
+	if rs.Backend != "docker" && rs.Backend != "tart" {
+		addError(path+".backend", "must be docker or tart")
+	}
+	if strings.TrimSpace(rs.Image) == "" {
+		addError(path+".image", "is required")
+	}
+	if rs.MaxRunners < 1 || rs.MaxRunners > 1000 {
+		addError(path+".max_runners", "must be between 1 and 1000")
+	}
+	if rs.Backend == "tart" && rs.Platform != "" {
+		addError(path+".platform", "must be empty for the tart backend")
+	}
+	if rs.Backend == "docker" && rs.Platform != "" && !strings.HasPrefix(rs.Platform, "linux/") {
+		addError(path+".platform", "must use linux/architecture format")
+	}
+}
+
+func validateWritablePath(path, yamlPath string, addError func(string, string)) {
+	if path == "" || path == ":memory:" {
+		return
+	}
+	dir := filepath.Dir(path)
+	if info, err := os.Stat(dir); err == nil {
+		if !info.IsDir() {
+			addError(yamlPath, "parent path is not a directory")
+			return
+		}
+		file, err := os.CreateTemp(dir, ".efr-write-check")
+		if err != nil {
+			addError(yamlPath, "parent directory is not writable: "+err.Error())
+			return
+		}
+		name := file.Name()
+		_ = file.Close()
+		_ = os.Remove(name)
+		return
+	}
+	parent := filepath.Dir(dir)
+	if _, err := os.Stat(parent); err != nil {
+		addError(yamlPath, "parent directory does not exist")
+	}
+}

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -4,9 +4,13 @@ import useSWR from 'swr'
 import { fetchSession, login, logout, setupAdmin } from './api/fetchers'
 import {
   fetchHostResources,
+  fetchConfigRevisions,
   fetchJobLogs,
   fetchJobResources,
   fetchJobs,
+  restoreConfigRevision,
+  saveConfig,
+  validateConfig,
 } from './api/fetchers'
 import { useDashboardSync } from './hooks/useDashboardSync'
 import { useDashboardStore } from './store/useDashboardStore'
@@ -189,7 +193,7 @@ function Console({ session, onLogout }: { session: SessionState; onLogout: () =>
           {page === 'overview' && <Overview />}
           {page === 'jobs' && <JobsPage jobs={store.recentJobs} now={store.now} />}
           {page === 'runner-sets' && <RunnerSetsPage runnerSets={store.runnerSets} />}
-          {page === 'config' && store.configStatus && <ConfigPage status={store.configStatus} />}
+          {page === 'config' && store.configStatus && <ConfigPage status={store.configStatus} csrfToken={session.csrfToken} />}
           {page === 'system' && <SystemPage />}
         </main>
       </div>
@@ -397,11 +401,63 @@ function RunnerSetsPage({ runnerSets }: { runnerSets: RunnerSet[] }) {
   )
 }
 
-function ConfigPage({ status }: { status: ConfigStatus }) {
+function ConfigPage({ status, csrfToken }: { status: ConfigStatus; csrfToken: string }) {
   const sameText = status.activeYAML === status.diskYAML
+  const [yaml, setYAML] = useState(status.diskYAML)
+  const [messages, setMessages] = useState<Array<{ path: string; message: string; tone: 'danger' | 'warning' }>>([])
+  const [saving, setSaving] = useState(false)
+  const [confirmWarnings, setConfirmWarnings] = useState(false)
+  const revisions = useSWR('configRevisions', fetchConfigRevisions)
+
+  useEffect(() => {
+    setYAML(status.diskYAML)
+  }, [status.diskHash, status.diskYAML])
+
+  async function check() {
+    const result = await validateConfig(yaml)
+    setMessages([
+      ...result.errors.map(issue => ({ ...issue, tone: 'danger' as const })),
+      ...result.warnings.map(issue => ({ ...issue, tone: 'warning' as const })),
+    ])
+    setConfirmWarnings(false)
+    return result
+  }
+
+  async function save() {
+    setSaving(true)
+    try {
+      const result = await check()
+      if (result.errors.length > 0) return
+      if (result.warnings.length > 0 && !confirmWarnings) {
+        setConfirmWarnings(true)
+        return
+      }
+      const saved = await saveConfig(yaml, csrfToken, confirmWarnings)
+      setConfirmWarnings(false)
+      setMessages(saved.warnings.map(issue => ({ ...issue, tone: 'warning' as const })))
+      await revisions.mutate()
+    } catch (error) {
+      setMessages([{ path: '$', message: String(error), tone: 'danger' }])
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function restore(id: number) {
+    setSaving(true)
+    try {
+      await restoreConfigRevision(id, csrfToken)
+      await revisions.mutate()
+    } catch (error) {
+      setMessages([{ path: '$', message: String(error), tone: 'danger' }])
+    } finally {
+      setSaving(false)
+    }
+  }
+
   return (
     <>
-      <PageHeader title="Config" detail="Read only view. Disk changes do not affect the running process." />
+      <PageHeader title="Config" detail="Validate and save the disk config. Restart the service manually to apply changes." />
       <div className={`notice ${status.state === 'disk_invalid' ? 'danger' : status.state === 'restart_required' ? 'warning' : 'success'}`}>
         <strong>{configStateLabel(status.state)}</strong>
         <span>
@@ -411,6 +467,12 @@ function ConfigPage({ status }: { status: ConfigStatus }) {
         </span>
       </div>
       {status.validationErrors.map(error => <div className="notice danger" key={error}>{error}</div>)}
+      {messages.map((message, index) => (
+        <div className={`notice ${message.tone}`} key={`${message.path}-${index}`}>
+          <strong>{message.path}</strong>
+          <span>{message.message}</span>
+        </div>
+      ))}
       <section className="panel">
         <PanelHeader title="Config identity" detail={status.path || 'No config file'} />
         <DefinitionList
@@ -428,11 +490,48 @@ function ConfigPage({ status }: { status: ConfigStatus }) {
           <pre>{status.activeYAML || 'No active YAML available.'}</pre>
         </section>
         <section className="panel">
-          <PanelHeader title="Disk config" detail={sameText ? 'Matches active text' : 'Differs from active text'} />
-          <pre>{status.diskYAML || 'No valid disk YAML available.'}</pre>
+          <PanelHeader title="Disk config editor" detail={sameText ? 'Matches active text' : 'Differs from active text'} />
+          <textarea className="config-editor" spellCheck={false} value={yaml} onChange={event => setYAML(event.target.value)} />
+          <div className="editor-actions">
+            <button className="text-button" disabled={saving} onClick={check}>Validate</button>
+            <button className="primary-button" disabled={saving} onClick={save}>{saving ? 'Working…' : confirmWarnings ? 'Save with warnings' : 'Save to disk'}</button>
+          </div>
         </section>
       </div>
+      {!sameText && <ConfigDiff active={status.activeYAML} disk={status.diskYAML} />}
+      {status.state === 'restart_required' && (
+        <section className="panel">
+          <PanelHeader title="Manual restart" detail="A restart can interrupt running jobs." />
+          {status.restartCommands.map(command => <pre key={command}>{command}</pre>)}
+        </section>
+      )}
+      <section className="panel">
+        <PanelHeader title="Recent revisions" detail="The newest ten saved versions" />
+        {revisions.data?.length
+          ? <div className="revision-list">{revisions.data.map(revision => (
+            <div key={revision.id}>
+              <span>{formatDate(revision.createdAt)} · {revision.source} · {shortenHash(revision.configHash)}</span>
+              <button className="text-button" disabled={saving} onClick={() => restore(revision.id)}>Restore to disk</button>
+            </div>
+          ))}</div>
+          : <EmptyState title="No revisions recorded" />}
+      </section>
     </>
+  )
+}
+
+function ConfigDiff({ active, disk }: { active: string; disk: string }) {
+  const activeLines = new Set(active.split('\n'))
+  const diskLines = new Set(disk.split('\n'))
+  const removed = active.split('\n').filter(line => line && !diskLines.has(line))
+  const added = disk.split('\n').filter(line => line && !activeLines.has(line))
+  return (
+    <section className="panel">
+      <PanelHeader title="Config diff" detail="Line changes between active and disk config" />
+      <pre className="config-diff">
+        {removed.map(line => `- ${line}`).concat(added.map(line => `+ ${line}`)).join('\n') || 'No line changes.'}
+      </pre>
+    </section>
   )
 }
 

--- a/dashboard/src/api/fetchers.ts
+++ b/dashboard/src/api/fetchers.ts
@@ -2,6 +2,8 @@ import type {
   Backend,
   BuildInfo,
   ConfigStatus,
+  ConfigValidation,
+  ConfigRevision,
   ConfigSyncState,
   DaemonStatus,
   DashboardSummary,
@@ -352,6 +354,7 @@ export async function fetchConfigStatus(): Promise<ConfigStatus> {
     validationErrors?: string[]
     activeYaml?: string
     diskYaml?: string
+    restartCommands?: string[]
   }>('GetConfigStatus')
   return {
     path: data.path ?? '',
@@ -363,6 +366,51 @@ export async function fetchConfigStatus(): Promise<ConfigStatus> {
     validationErrors: data.validationErrors ?? [],
     activeYAML: data.activeYaml ?? '',
     diskYAML: data.diskYaml ?? '',
+    restartCommands: data.restartCommands ?? [],
+  }
+}
+
+export async function validateConfig(yaml: string): Promise<ConfigValidation> {
+  const data = await rpc<ValidationResponse>('ValidateConfig', { yaml })
+  return toValidation(data)
+}
+
+export async function saveConfig(yaml: string, csrfToken: string, confirmWarnings = false): Promise<ConfigValidation> {
+  const data = await rpc<{ validation?: ValidationResponse }>(
+    'SaveConfig',
+    { yaml, confirmWarnings },
+    csrfToken,
+  )
+  return toValidation(data.validation ?? {})
+}
+
+export async function fetchConfigRevisions(): Promise<ConfigRevision[]> {
+  const data = await rpc<{
+    revisions?: Array<{ id: number; createdAt: string; source: string; configHash: string }>
+  }>('ListConfigRevisions')
+  return (data.revisions ?? []).map(revision => ({
+    id: revision.id,
+    createdAt: new Date(revision.createdAt),
+    source: revision.source,
+    configHash: revision.configHash,
+  }))
+}
+
+export async function restoreConfigRevision(id: number, csrfToken: string): Promise<void> {
+  await rpc('RestoreConfigRevision', { id }, csrfToken)
+}
+
+interface ValidationResponse {
+  errors?: Array<{ path?: string; message?: string }>
+  warnings?: Array<{ path?: string; message?: string }>
+  normalizedYaml?: string
+}
+
+function toValidation(data: ValidationResponse): ConfigValidation {
+  return {
+    errors: (data.errors ?? []).map(issue => ({ path: issue.path ?? '$', message: issue.message ?? '' })),
+    warnings: (data.warnings ?? []).map(issue => ({ path: issue.path ?? '$', message: issue.message ?? '' })),
+    normalizedYAML: data.normalizedYaml ?? '',
   }
 }
 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -612,6 +612,43 @@ input:focus {
   vector-effect: non-scaling-stroke;
 }
 
+.config-editor {
+  width: 100%;
+  min-height: 520px;
+  padding: 14px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  outline: none;
+  color: var(--text);
+  background: #090b0e;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.config-editor:focus {
+  border-color: var(--blue);
+}
+
+.editor-actions {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.revision-list > div {
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--dim);
+  font-size: 11px;
+}
+
 .empty-state,
 .full-page-message {
   color: var(--dim);

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -124,6 +124,25 @@ export interface ConfigStatus {
   validationErrors: string[]
   activeYAML: string
   diskYAML: string
+  restartCommands: string[]
+}
+
+export interface ConfigValidationIssue {
+  path: string
+  message: string
+}
+
+export interface ConfigValidation {
+  errors: ConfigValidationIssue[]
+  warnings: ConfigValidationIssue[]
+  normalizedYAML: string
+}
+
+export interface ConfigRevision {
+  id: number
+  createdAt: Date
+  source: string
+  configHash: string
 }
 
 export interface SystemInfo {

--- a/gen/controlplane/v1/controlplane.pb.go
+++ b/gen/controlplane/v1/controlplane.pb.go
@@ -2413,6 +2413,7 @@ type GetConfigStatusResponse struct {
 	ValidationErrors []string               `protobuf:"bytes,7,rep,name=validation_errors,json=validationErrors,proto3" json:"validation_errors,omitempty"`
 	ActiveYaml       string                 `protobuf:"bytes,8,opt,name=active_yaml,json=activeYaml,proto3" json:"active_yaml,omitempty"`
 	DiskYaml         string                 `protobuf:"bytes,9,opt,name=disk_yaml,json=diskYaml,proto3" json:"disk_yaml,omitempty"`
+	RestartCommands  []string               `protobuf:"bytes,10,rep,name=restart_commands,json=restartCommands,proto3" json:"restart_commands,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -2510,6 +2511,509 @@ func (x *GetConfigStatusResponse) GetDiskYaml() string {
 	return ""
 }
 
+func (x *GetConfigStatusResponse) GetRestartCommands() []string {
+	if x != nil {
+		return x.RestartCommands
+	}
+	return nil
+}
+
+type ConfigValidationIssue struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigValidationIssue) Reset() {
+	*x = ConfigValidationIssue{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigValidationIssue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigValidationIssue) ProtoMessage() {}
+
+func (x *ConfigValidationIssue) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigValidationIssue.ProtoReflect.Descriptor instead.
+func (*ConfigValidationIssue) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *ConfigValidationIssue) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *ConfigValidationIssue) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+type ValidateConfigRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Yaml          string                 `protobuf:"bytes,1,opt,name=yaml,proto3" json:"yaml,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ValidateConfigRequest) Reset() {
+	*x = ValidateConfigRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateConfigRequest) ProtoMessage() {}
+
+func (x *ValidateConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateConfigRequest.ProtoReflect.Descriptor instead.
+func (*ValidateConfigRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *ValidateConfigRequest) GetYaml() string {
+	if x != nil {
+		return x.Yaml
+	}
+	return ""
+}
+
+type ValidateConfigResponse struct {
+	state          protoimpl.MessageState   `protogen:"open.v1"`
+	Errors         []*ConfigValidationIssue `protobuf:"bytes,1,rep,name=errors,proto3" json:"errors,omitempty"`
+	Warnings       []*ConfigValidationIssue `protobuf:"bytes,2,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	NormalizedYaml string                   `protobuf:"bytes,3,opt,name=normalized_yaml,json=normalizedYaml,proto3" json:"normalized_yaml,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ValidateConfigResponse) Reset() {
+	*x = ValidateConfigResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateConfigResponse) ProtoMessage() {}
+
+func (x *ValidateConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateConfigResponse.ProtoReflect.Descriptor instead.
+func (*ValidateConfigResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *ValidateConfigResponse) GetErrors() []*ConfigValidationIssue {
+	if x != nil {
+		return x.Errors
+	}
+	return nil
+}
+
+func (x *ValidateConfigResponse) GetWarnings() []*ConfigValidationIssue {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
+
+func (x *ValidateConfigResponse) GetNormalizedYaml() string {
+	if x != nil {
+		return x.NormalizedYaml
+	}
+	return ""
+}
+
+type SaveConfigRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Yaml            string                 `protobuf:"bytes,1,opt,name=yaml,proto3" json:"yaml,omitempty"`
+	ConfirmWarnings bool                   `protobuf:"varint,2,opt,name=confirm_warnings,json=confirmWarnings,proto3" json:"confirm_warnings,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SaveConfigRequest) Reset() {
+	*x = SaveConfigRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveConfigRequest) ProtoMessage() {}
+
+func (x *SaveConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveConfigRequest.ProtoReflect.Descriptor instead.
+func (*SaveConfigRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *SaveConfigRequest) GetYaml() string {
+	if x != nil {
+		return x.Yaml
+	}
+	return ""
+}
+
+func (x *SaveConfigRequest) GetConfirmWarnings() bool {
+	if x != nil {
+		return x.ConfirmWarnings
+	}
+	return false
+}
+
+type SaveConfigResponse struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Validation    *ValidateConfigResponse  `protobuf:"bytes,1,opt,name=validation,proto3" json:"validation,omitempty"`
+	Status        *GetConfigStatusResponse `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SaveConfigResponse) Reset() {
+	*x = SaveConfigResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveConfigResponse) ProtoMessage() {}
+
+func (x *SaveConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveConfigResponse.ProtoReflect.Descriptor instead.
+func (*SaveConfigResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *SaveConfigResponse) GetValidation() *ValidateConfigResponse {
+	if x != nil {
+		return x.Validation
+	}
+	return nil
+}
+
+func (x *SaveConfigResponse) GetStatus() *GetConfigStatusResponse {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+type ConfigRevision struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	Source        string                 `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
+	ConfigHash    string                 `protobuf:"bytes,4,opt,name=config_hash,json=configHash,proto3" json:"config_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigRevision) Reset() {
+	*x = ConfigRevision{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigRevision) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigRevision) ProtoMessage() {}
+
+func (x *ConfigRevision) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigRevision.ProtoReflect.Descriptor instead.
+func (*ConfigRevision) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *ConfigRevision) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ConfigRevision) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *ConfigRevision) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *ConfigRevision) GetConfigHash() string {
+	if x != nil {
+		return x.ConfigHash
+	}
+	return ""
+}
+
+type ListConfigRevisionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListConfigRevisionsRequest) Reset() {
+	*x = ListConfigRevisionsRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListConfigRevisionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListConfigRevisionsRequest) ProtoMessage() {}
+
+func (x *ListConfigRevisionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListConfigRevisionsRequest.ProtoReflect.Descriptor instead.
+func (*ListConfigRevisionsRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{42}
+}
+
+type ListConfigRevisionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Revisions     []*ConfigRevision      `protobuf:"bytes,1,rep,name=revisions,proto3" json:"revisions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListConfigRevisionsResponse) Reset() {
+	*x = ListConfigRevisionsResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListConfigRevisionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListConfigRevisionsResponse) ProtoMessage() {}
+
+func (x *ListConfigRevisionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListConfigRevisionsResponse.ProtoReflect.Descriptor instead.
+func (*ListConfigRevisionsResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *ListConfigRevisionsResponse) GetRevisions() []*ConfigRevision {
+	if x != nil {
+		return x.Revisions
+	}
+	return nil
+}
+
+type RestoreConfigRevisionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreConfigRevisionRequest) Reset() {
+	*x = RestoreConfigRevisionRequest{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreConfigRevisionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreConfigRevisionRequest) ProtoMessage() {}
+
+func (x *RestoreConfigRevisionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreConfigRevisionRequest.ProtoReflect.Descriptor instead.
+func (*RestoreConfigRevisionRequest) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *RestoreConfigRevisionRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+type RestoreConfigRevisionResponse struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Status        *GetConfigStatusResponse `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreConfigRevisionResponse) Reset() {
+	*x = RestoreConfigRevisionResponse{}
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreConfigRevisionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreConfigRevisionResponse) ProtoMessage() {}
+
+func (x *RestoreConfigRevisionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreConfigRevisionResponse.ProtoReflect.Descriptor instead.
+func (*RestoreConfigRevisionResponse) Descriptor() ([]byte, []int) {
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *RestoreConfigRevisionResponse) GetStatus() *GetConfigStatusResponse {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
 type GetSystemInfoRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2518,7 +3022,7 @@ type GetSystemInfoRequest struct {
 
 func (x *GetSystemInfoRequest) Reset() {
 	*x = GetSystemInfoRequest{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[36]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2530,7 +3034,7 @@ func (x *GetSystemInfoRequest) String() string {
 func (*GetSystemInfoRequest) ProtoMessage() {}
 
 func (x *GetSystemInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[36]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2543,7 +3047,7 @@ func (x *GetSystemInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetSystemInfoRequest) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{36}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{46}
 }
 
 type GetSystemInfoResponse struct {
@@ -2559,7 +3063,7 @@ type GetSystemInfoResponse struct {
 
 func (x *GetSystemInfoResponse) Reset() {
 	*x = GetSystemInfoResponse{}
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[37]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2571,7 +3075,7 @@ func (x *GetSystemInfoResponse) String() string {
 func (*GetSystemInfoResponse) ProtoMessage() {}
 
 func (x *GetSystemInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_controlplane_v1_controlplane_proto_msgTypes[37]
+	mi := &file_controlplane_v1_controlplane_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2584,7 +3088,7 @@ func (x *GetSystemInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetSystemInfoResponse) Descriptor() ([]byte, []int) {
-	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{37}
+	return file_controlplane_v1_controlplane_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetSystemInfoResponse) GetOs() string {
@@ -2802,7 +3306,7 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x14memory_usage_percent\x18\x02 \x01(\x02R\x12memoryUsagePercent\x12,\n" +
 	"\x12disk_usage_percent\x18\x03 \x01(\x02R\x10diskUsagePercent\x12/\n" +
 	"\x13temperature_celsius\x18\x04 \x01(\x02R\x12temperatureCelsius\"\x18\n" +
-	"\x16GetConfigStatusRequest\"\xb4\x03\n" +
+	"\x16GetConfigStatusRequest\"\xdf\x03\n" +
 	"\x17GetConfigStatusResponse\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1f\n" +
 	"\vactive_hash\x18\x02 \x01(\tR\n" +
@@ -2814,8 +3318,41 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x11validation_errors\x18\a \x03(\tR\x10validationErrors\x12\x1f\n" +
 	"\vactive_yaml\x18\b \x01(\tR\n" +
 	"activeYaml\x12\x1b\n" +
-	"\tdisk_yaml\x18\t \x01(\tR\bdiskYamlB\x13\n" +
-	"\x11_disk_modified_at\"\x16\n" +
+	"\tdisk_yaml\x18\t \x01(\tR\bdiskYaml\x12)\n" +
+	"\x10restart_commands\x18\n" +
+	" \x03(\tR\x0frestartCommandsB\x13\n" +
+	"\x11_disk_modified_at\"E\n" +
+	"\x15ConfigValidationIssue\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"+\n" +
+	"\x15ValidateConfigRequest\x12\x12\n" +
+	"\x04yaml\x18\x01 \x01(\tR\x04yaml\"\xc5\x01\n" +
+	"\x16ValidateConfigResponse\x12>\n" +
+	"\x06errors\x18\x01 \x03(\v2&.controlplane.v1.ConfigValidationIssueR\x06errors\x12B\n" +
+	"\bwarnings\x18\x02 \x03(\v2&.controlplane.v1.ConfigValidationIssueR\bwarnings\x12'\n" +
+	"\x0fnormalized_yaml\x18\x03 \x01(\tR\x0enormalizedYaml\"R\n" +
+	"\x11SaveConfigRequest\x12\x12\n" +
+	"\x04yaml\x18\x01 \x01(\tR\x04yaml\x12)\n" +
+	"\x10confirm_warnings\x18\x02 \x01(\bR\x0fconfirmWarnings\"\x9f\x01\n" +
+	"\x12SaveConfigResponse\x12G\n" +
+	"\n" +
+	"validation\x18\x01 \x01(\v2'.controlplane.v1.ValidateConfigResponseR\n" +
+	"validation\x12@\n" +
+	"\x06status\x18\x02 \x01(\v2(.controlplane.v1.GetConfigStatusResponseR\x06status\"\x94\x01\n" +
+	"\x0eConfigRevision\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x129\n" +
+	"\n" +
+	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x16\n" +
+	"\x06source\x18\x03 \x01(\tR\x06source\x12\x1f\n" +
+	"\vconfig_hash\x18\x04 \x01(\tR\n" +
+	"configHash\"\x1c\n" +
+	"\x1aListConfigRevisionsRequest\"\\\n" +
+	"\x1bListConfigRevisionsResponse\x12=\n" +
+	"\trevisions\x18\x01 \x03(\v2\x1f.controlplane.v1.ConfigRevisionR\trevisions\".\n" +
+	"\x1cRestoreConfigRevisionRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\"a\n" +
+	"\x1dRestoreConfigRevisionResponse\x12@\n" +
+	"\x06status\x18\x01 \x01(\v2(.controlplane.v1.GetConfigStatusResponseR\x06status\"\x16\n" +
 	"\x14GetSystemInfoRequest\"\xaf\x01\n" +
 	"\x15GetSystemInfoResponse\x12\x0e\n" +
 	"\x02os\x18\x01 \x01(\tR\x02os\x12\x12\n" +
@@ -2847,7 +3384,7 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x1dCONFIG_SYNC_STATE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19CONFIG_SYNC_STATE_IN_SYNC\x10\x01\x12&\n" +
 	"\"CONFIG_SYNC_STATE_RESTART_REQUIRED\x10\x02\x12\"\n" +
-	"\x1eCONFIG_SYNC_STATE_DISK_INVALID\x10\x032\xc7\v\n" +
+	"\x1eCONFIG_SYNC_STATE_DISK_INVALID\x10\x032\xeb\x0e\n" +
 	"\x13ControlPlaneService\x12U\n" +
 	"\n" +
 	"GetSession\x12\".controlplane.v1.GetSessionRequest\x1a#.controlplane.v1.GetSessionResponse\x12U\n" +
@@ -2865,7 +3402,12 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x15GetJobResourceSamples\x12-.controlplane.v1.GetJobResourceSamplesRequest\x1a..controlplane.v1.GetJobResourceSamplesResponse\x12y\n" +
 	"\x16GetHostResourceSamples\x12..controlplane.v1.GetHostResourceSamplesRequest\x1a/.controlplane.v1.GetHostResourceSamplesResponse\x12g\n" +
 	"\x10GetMachineVitals\x12(.controlplane.v1.GetMachineVitalsRequest\x1a).controlplane.v1.GetMachineVitalsResponse\x12d\n" +
-	"\x0fGetConfigStatus\x12'.controlplane.v1.GetConfigStatusRequest\x1a(.controlplane.v1.GetConfigStatusResponse\x12^\n" +
+	"\x0fGetConfigStatus\x12'.controlplane.v1.GetConfigStatusRequest\x1a(.controlplane.v1.GetConfigStatusResponse\x12a\n" +
+	"\x0eValidateConfig\x12&.controlplane.v1.ValidateConfigRequest\x1a'.controlplane.v1.ValidateConfigResponse\x12U\n" +
+	"\n" +
+	"SaveConfig\x12\".controlplane.v1.SaveConfigRequest\x1a#.controlplane.v1.SaveConfigResponse\x12p\n" +
+	"\x13ListConfigRevisions\x12+.controlplane.v1.ListConfigRevisionsRequest\x1a,.controlplane.v1.ListConfigRevisionsResponse\x12v\n" +
+	"\x15RestoreConfigRevision\x12-.controlplane.v1.RestoreConfigRevisionRequest\x1a..controlplane.v1.RestoreConfigRevisionResponse\x12^\n" +
 	"\rGetSystemInfo\x12%.controlplane.v1.GetSystemInfoRequest\x1a&.controlplane.v1.GetSystemInfoResponseBRZPgithub.com/boring-design/elastic-fruit-runner/gen/controlplane/v1;controlplanev1b\x06proto3"
 
 var (
@@ -2881,7 +3423,7 @@ func file_controlplane_v1_controlplane_proto_rawDescGZIP() []byte {
 }
 
 var file_controlplane_v1_controlplane_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_controlplane_v1_controlplane_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_controlplane_v1_controlplane_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_controlplane_v1_controlplane_proto_goTypes = []any{
 	(Backend)(0),                           // 0: controlplane.v1.Backend
 	(RunnerState)(0),                       // 1: controlplane.v1.RunnerState
@@ -2924,13 +3466,23 @@ var file_controlplane_v1_controlplane_proto_goTypes = []any{
 	(*GetMachineVitalsResponse)(nil),       // 38: controlplane.v1.GetMachineVitalsResponse
 	(*GetConfigStatusRequest)(nil),         // 39: controlplane.v1.GetConfigStatusRequest
 	(*GetConfigStatusResponse)(nil),        // 40: controlplane.v1.GetConfigStatusResponse
-	(*GetSystemInfoRequest)(nil),           // 41: controlplane.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil),          // 42: controlplane.v1.GetSystemInfoResponse
-	(*timestamppb.Timestamp)(nil),          // 43: google.protobuf.Timestamp
+	(*ConfigValidationIssue)(nil),          // 41: controlplane.v1.ConfigValidationIssue
+	(*ValidateConfigRequest)(nil),          // 42: controlplane.v1.ValidateConfigRequest
+	(*ValidateConfigResponse)(nil),         // 43: controlplane.v1.ValidateConfigResponse
+	(*SaveConfigRequest)(nil),              // 44: controlplane.v1.SaveConfigRequest
+	(*SaveConfigResponse)(nil),             // 45: controlplane.v1.SaveConfigResponse
+	(*ConfigRevision)(nil),                 // 46: controlplane.v1.ConfigRevision
+	(*ListConfigRevisionsRequest)(nil),     // 47: controlplane.v1.ListConfigRevisionsRequest
+	(*ListConfigRevisionsResponse)(nil),    // 48: controlplane.v1.ListConfigRevisionsResponse
+	(*RestoreConfigRevisionRequest)(nil),   // 49: controlplane.v1.RestoreConfigRevisionRequest
+	(*RestoreConfigRevisionResponse)(nil),  // 50: controlplane.v1.RestoreConfigRevisionResponse
+	(*GetSystemInfoRequest)(nil),           // 51: controlplane.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),          // 52: controlplane.v1.GetSystemInfoResponse
+	(*timestamppb.Timestamp)(nil),          // 53: google.protobuf.Timestamp
 }
 var file_controlplane_v1_controlplane_proto_depIdxs = []int32{
 	17, // 0: controlplane.v1.GetServiceInfoResponse.build_info:type_name -> controlplane.v1.BuildInfo
-	43, // 1: controlplane.v1.GetServiceInfoResponse.started_at:type_name -> google.protobuf.Timestamp
+	53, // 1: controlplane.v1.GetServiceInfoResponse.started_at:type_name -> google.protobuf.Timestamp
 	18, // 2: controlplane.v1.BuildInfo.main:type_name -> controlplane.v1.Module
 	18, // 3: controlplane.v1.BuildInfo.deps:type_name -> controlplane.v1.Module
 	19, // 4: controlplane.v1.BuildInfo.settings:type_name -> controlplane.v1.BuildSetting
@@ -2939,65 +3491,80 @@ var file_controlplane_v1_controlplane_proto_depIdxs = []int32{
 	0,  // 7: controlplane.v1.RunnerSet.backend:type_name -> controlplane.v1.Backend
 	23, // 8: controlplane.v1.RunnerSet.runners:type_name -> controlplane.v1.Runner
 	1,  // 9: controlplane.v1.Runner.state:type_name -> controlplane.v1.RunnerState
-	43, // 10: controlplane.v1.Runner.since:type_name -> google.protobuf.Timestamp
-	43, // 11: controlplane.v1.ListJobRecordsRequest.from:type_name -> google.protobuf.Timestamp
-	43, // 12: controlplane.v1.ListJobRecordsRequest.to:type_name -> google.protobuf.Timestamp
+	53, // 10: controlplane.v1.Runner.since:type_name -> google.protobuf.Timestamp
+	53, // 11: controlplane.v1.ListJobRecordsRequest.from:type_name -> google.protobuf.Timestamp
+	53, // 12: controlplane.v1.ListJobRecordsRequest.to:type_name -> google.protobuf.Timestamp
 	26, // 13: controlplane.v1.ListJobRecordsResponse.job_records:type_name -> controlplane.v1.JobRecord
 	2,  // 14: controlplane.v1.JobRecord.result:type_name -> controlplane.v1.JobResult
-	43, // 15: controlplane.v1.JobRecord.started_at:type_name -> google.protobuf.Timestamp
-	43, // 16: controlplane.v1.JobRecord.completed_at:type_name -> google.protobuf.Timestamp
-	43, // 17: controlplane.v1.JobRecord.queued_at:type_name -> google.protobuf.Timestamp
-	43, // 18: controlplane.v1.JobRecord.scale_set_assigned_at:type_name -> google.protobuf.Timestamp
-	43, // 19: controlplane.v1.JobRecord.runner_assigned_at:type_name -> google.protobuf.Timestamp
+	53, // 15: controlplane.v1.JobRecord.started_at:type_name -> google.protobuf.Timestamp
+	53, // 16: controlplane.v1.JobRecord.completed_at:type_name -> google.protobuf.Timestamp
+	53, // 17: controlplane.v1.JobRecord.queued_at:type_name -> google.protobuf.Timestamp
+	53, // 18: controlplane.v1.JobRecord.scale_set_assigned_at:type_name -> google.protobuf.Timestamp
+	53, // 19: controlplane.v1.JobRecord.runner_assigned_at:type_name -> google.protobuf.Timestamp
 	0,  // 20: controlplane.v1.JobRecord.backend:type_name -> controlplane.v1.Backend
 	26, // 21: controlplane.v1.GetJobDetailResponse.job:type_name -> controlplane.v1.JobRecord
-	43, // 22: controlplane.v1.JobLogLine.recorded_at:type_name -> google.protobuf.Timestamp
+	53, // 22: controlplane.v1.JobLogLine.recorded_at:type_name -> google.protobuf.Timestamp
 	30, // 23: controlplane.v1.GetJobLogsResponse.lines:type_name -> controlplane.v1.JobLogLine
-	43, // 24: controlplane.v1.ResourceSample.recorded_at:type_name -> google.protobuf.Timestamp
+	53, // 24: controlplane.v1.ResourceSample.recorded_at:type_name -> google.protobuf.Timestamp
 	3,  // 25: controlplane.v1.ResourceSample.accuracy:type_name -> controlplane.v1.ResourceAccuracy
 	32, // 26: controlplane.v1.GetJobResourceSamplesResponse.samples:type_name -> controlplane.v1.ResourceSample
-	43, // 27: controlplane.v1.GetHostResourceSamplesRequest.from:type_name -> google.protobuf.Timestamp
-	43, // 28: controlplane.v1.GetHostResourceSamplesRequest.to:type_name -> google.protobuf.Timestamp
+	53, // 27: controlplane.v1.GetHostResourceSamplesRequest.from:type_name -> google.protobuf.Timestamp
+	53, // 28: controlplane.v1.GetHostResourceSamplesRequest.to:type_name -> google.protobuf.Timestamp
 	32, // 29: controlplane.v1.GetHostResourceSamplesResponse.samples:type_name -> controlplane.v1.ResourceSample
-	43, // 30: controlplane.v1.GetHostResourceSamplesResponse.earliest_at:type_name -> google.protobuf.Timestamp
+	53, // 30: controlplane.v1.GetHostResourceSamplesResponse.earliest_at:type_name -> google.protobuf.Timestamp
 	4,  // 31: controlplane.v1.GetConfigStatusResponse.state:type_name -> controlplane.v1.ConfigSyncState
-	43, // 32: controlplane.v1.GetConfigStatusResponse.disk_modified_at:type_name -> google.protobuf.Timestamp
-	43, // 33: controlplane.v1.GetConfigStatusResponse.active_loaded_at:type_name -> google.protobuf.Timestamp
-	5,  // 34: controlplane.v1.ControlPlaneService.GetSession:input_type -> controlplane.v1.GetSessionRequest
-	7,  // 35: controlplane.v1.ControlPlaneService.SetupAdmin:input_type -> controlplane.v1.SetupAdminRequest
-	9,  // 36: controlplane.v1.ControlPlaneService.Login:input_type -> controlplane.v1.LoginRequest
-	11, // 37: controlplane.v1.ControlPlaneService.Logout:input_type -> controlplane.v1.LogoutRequest
-	13, // 38: controlplane.v1.ControlPlaneService.GetServiceInfo:input_type -> controlplane.v1.GetServiceInfoRequest
-	15, // 39: controlplane.v1.ControlPlaneService.GetDashboardSummary:input_type -> controlplane.v1.GetDashboardSummaryRequest
-	20, // 40: controlplane.v1.ControlPlaneService.ListRunnerSets:input_type -> controlplane.v1.ListRunnerSetsRequest
-	24, // 41: controlplane.v1.ControlPlaneService.ListJobRecords:input_type -> controlplane.v1.ListJobRecordsRequest
-	27, // 42: controlplane.v1.ControlPlaneService.GetJobDetail:input_type -> controlplane.v1.GetJobDetailRequest
-	29, // 43: controlplane.v1.ControlPlaneService.GetJobLogs:input_type -> controlplane.v1.GetJobLogsRequest
-	33, // 44: controlplane.v1.ControlPlaneService.GetJobResourceSamples:input_type -> controlplane.v1.GetJobResourceSamplesRequest
-	35, // 45: controlplane.v1.ControlPlaneService.GetHostResourceSamples:input_type -> controlplane.v1.GetHostResourceSamplesRequest
-	37, // 46: controlplane.v1.ControlPlaneService.GetMachineVitals:input_type -> controlplane.v1.GetMachineVitalsRequest
-	39, // 47: controlplane.v1.ControlPlaneService.GetConfigStatus:input_type -> controlplane.v1.GetConfigStatusRequest
-	41, // 48: controlplane.v1.ControlPlaneService.GetSystemInfo:input_type -> controlplane.v1.GetSystemInfoRequest
-	6,  // 49: controlplane.v1.ControlPlaneService.GetSession:output_type -> controlplane.v1.GetSessionResponse
-	8,  // 50: controlplane.v1.ControlPlaneService.SetupAdmin:output_type -> controlplane.v1.SetupAdminResponse
-	10, // 51: controlplane.v1.ControlPlaneService.Login:output_type -> controlplane.v1.LoginResponse
-	12, // 52: controlplane.v1.ControlPlaneService.Logout:output_type -> controlplane.v1.LogoutResponse
-	14, // 53: controlplane.v1.ControlPlaneService.GetServiceInfo:output_type -> controlplane.v1.GetServiceInfoResponse
-	16, // 54: controlplane.v1.ControlPlaneService.GetDashboardSummary:output_type -> controlplane.v1.GetDashboardSummaryResponse
-	21, // 55: controlplane.v1.ControlPlaneService.ListRunnerSets:output_type -> controlplane.v1.ListRunnerSetsResponse
-	25, // 56: controlplane.v1.ControlPlaneService.ListJobRecords:output_type -> controlplane.v1.ListJobRecordsResponse
-	28, // 57: controlplane.v1.ControlPlaneService.GetJobDetail:output_type -> controlplane.v1.GetJobDetailResponse
-	31, // 58: controlplane.v1.ControlPlaneService.GetJobLogs:output_type -> controlplane.v1.GetJobLogsResponse
-	34, // 59: controlplane.v1.ControlPlaneService.GetJobResourceSamples:output_type -> controlplane.v1.GetJobResourceSamplesResponse
-	36, // 60: controlplane.v1.ControlPlaneService.GetHostResourceSamples:output_type -> controlplane.v1.GetHostResourceSamplesResponse
-	38, // 61: controlplane.v1.ControlPlaneService.GetMachineVitals:output_type -> controlplane.v1.GetMachineVitalsResponse
-	40, // 62: controlplane.v1.ControlPlaneService.GetConfigStatus:output_type -> controlplane.v1.GetConfigStatusResponse
-	42, // 63: controlplane.v1.ControlPlaneService.GetSystemInfo:output_type -> controlplane.v1.GetSystemInfoResponse
-	49, // [49:64] is the sub-list for method output_type
-	34, // [34:49] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	53, // 32: controlplane.v1.GetConfigStatusResponse.disk_modified_at:type_name -> google.protobuf.Timestamp
+	53, // 33: controlplane.v1.GetConfigStatusResponse.active_loaded_at:type_name -> google.protobuf.Timestamp
+	41, // 34: controlplane.v1.ValidateConfigResponse.errors:type_name -> controlplane.v1.ConfigValidationIssue
+	41, // 35: controlplane.v1.ValidateConfigResponse.warnings:type_name -> controlplane.v1.ConfigValidationIssue
+	43, // 36: controlplane.v1.SaveConfigResponse.validation:type_name -> controlplane.v1.ValidateConfigResponse
+	40, // 37: controlplane.v1.SaveConfigResponse.status:type_name -> controlplane.v1.GetConfigStatusResponse
+	53, // 38: controlplane.v1.ConfigRevision.created_at:type_name -> google.protobuf.Timestamp
+	46, // 39: controlplane.v1.ListConfigRevisionsResponse.revisions:type_name -> controlplane.v1.ConfigRevision
+	40, // 40: controlplane.v1.RestoreConfigRevisionResponse.status:type_name -> controlplane.v1.GetConfigStatusResponse
+	5,  // 41: controlplane.v1.ControlPlaneService.GetSession:input_type -> controlplane.v1.GetSessionRequest
+	7,  // 42: controlplane.v1.ControlPlaneService.SetupAdmin:input_type -> controlplane.v1.SetupAdminRequest
+	9,  // 43: controlplane.v1.ControlPlaneService.Login:input_type -> controlplane.v1.LoginRequest
+	11, // 44: controlplane.v1.ControlPlaneService.Logout:input_type -> controlplane.v1.LogoutRequest
+	13, // 45: controlplane.v1.ControlPlaneService.GetServiceInfo:input_type -> controlplane.v1.GetServiceInfoRequest
+	15, // 46: controlplane.v1.ControlPlaneService.GetDashboardSummary:input_type -> controlplane.v1.GetDashboardSummaryRequest
+	20, // 47: controlplane.v1.ControlPlaneService.ListRunnerSets:input_type -> controlplane.v1.ListRunnerSetsRequest
+	24, // 48: controlplane.v1.ControlPlaneService.ListJobRecords:input_type -> controlplane.v1.ListJobRecordsRequest
+	27, // 49: controlplane.v1.ControlPlaneService.GetJobDetail:input_type -> controlplane.v1.GetJobDetailRequest
+	29, // 50: controlplane.v1.ControlPlaneService.GetJobLogs:input_type -> controlplane.v1.GetJobLogsRequest
+	33, // 51: controlplane.v1.ControlPlaneService.GetJobResourceSamples:input_type -> controlplane.v1.GetJobResourceSamplesRequest
+	35, // 52: controlplane.v1.ControlPlaneService.GetHostResourceSamples:input_type -> controlplane.v1.GetHostResourceSamplesRequest
+	37, // 53: controlplane.v1.ControlPlaneService.GetMachineVitals:input_type -> controlplane.v1.GetMachineVitalsRequest
+	39, // 54: controlplane.v1.ControlPlaneService.GetConfigStatus:input_type -> controlplane.v1.GetConfigStatusRequest
+	42, // 55: controlplane.v1.ControlPlaneService.ValidateConfig:input_type -> controlplane.v1.ValidateConfigRequest
+	44, // 56: controlplane.v1.ControlPlaneService.SaveConfig:input_type -> controlplane.v1.SaveConfigRequest
+	47, // 57: controlplane.v1.ControlPlaneService.ListConfigRevisions:input_type -> controlplane.v1.ListConfigRevisionsRequest
+	49, // 58: controlplane.v1.ControlPlaneService.RestoreConfigRevision:input_type -> controlplane.v1.RestoreConfigRevisionRequest
+	51, // 59: controlplane.v1.ControlPlaneService.GetSystemInfo:input_type -> controlplane.v1.GetSystemInfoRequest
+	6,  // 60: controlplane.v1.ControlPlaneService.GetSession:output_type -> controlplane.v1.GetSessionResponse
+	8,  // 61: controlplane.v1.ControlPlaneService.SetupAdmin:output_type -> controlplane.v1.SetupAdminResponse
+	10, // 62: controlplane.v1.ControlPlaneService.Login:output_type -> controlplane.v1.LoginResponse
+	12, // 63: controlplane.v1.ControlPlaneService.Logout:output_type -> controlplane.v1.LogoutResponse
+	14, // 64: controlplane.v1.ControlPlaneService.GetServiceInfo:output_type -> controlplane.v1.GetServiceInfoResponse
+	16, // 65: controlplane.v1.ControlPlaneService.GetDashboardSummary:output_type -> controlplane.v1.GetDashboardSummaryResponse
+	21, // 66: controlplane.v1.ControlPlaneService.ListRunnerSets:output_type -> controlplane.v1.ListRunnerSetsResponse
+	25, // 67: controlplane.v1.ControlPlaneService.ListJobRecords:output_type -> controlplane.v1.ListJobRecordsResponse
+	28, // 68: controlplane.v1.ControlPlaneService.GetJobDetail:output_type -> controlplane.v1.GetJobDetailResponse
+	31, // 69: controlplane.v1.ControlPlaneService.GetJobLogs:output_type -> controlplane.v1.GetJobLogsResponse
+	34, // 70: controlplane.v1.ControlPlaneService.GetJobResourceSamples:output_type -> controlplane.v1.GetJobResourceSamplesResponse
+	36, // 71: controlplane.v1.ControlPlaneService.GetHostResourceSamples:output_type -> controlplane.v1.GetHostResourceSamplesResponse
+	38, // 72: controlplane.v1.ControlPlaneService.GetMachineVitals:output_type -> controlplane.v1.GetMachineVitalsResponse
+	40, // 73: controlplane.v1.ControlPlaneService.GetConfigStatus:output_type -> controlplane.v1.GetConfigStatusResponse
+	43, // 74: controlplane.v1.ControlPlaneService.ValidateConfig:output_type -> controlplane.v1.ValidateConfigResponse
+	45, // 75: controlplane.v1.ControlPlaneService.SaveConfig:output_type -> controlplane.v1.SaveConfigResponse
+	48, // 76: controlplane.v1.ControlPlaneService.ListConfigRevisions:output_type -> controlplane.v1.ListConfigRevisionsResponse
+	50, // 77: controlplane.v1.ControlPlaneService.RestoreConfigRevision:output_type -> controlplane.v1.RestoreConfigRevisionResponse
+	52, // 78: controlplane.v1.ControlPlaneService.GetSystemInfo:output_type -> controlplane.v1.GetSystemInfoResponse
+	60, // [60:79] is the sub-list for method output_type
+	41, // [41:60] is the sub-list for method input_type
+	41, // [41:41] is the sub-list for extension type_name
+	41, // [41:41] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_controlplane_v1_controlplane_proto_init() }
@@ -3016,7 +3583,7 @@ func file_controlplane_v1_controlplane_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_controlplane_v1_controlplane_proto_rawDesc), len(file_controlplane_v1_controlplane_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   38,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/controlplane/v1/controlplanev1connect/controlplane.connect.go
+++ b/gen/controlplane/v1/controlplanev1connect/controlplane.connect.go
@@ -76,6 +76,18 @@ const (
 	// ControlPlaneServiceGetConfigStatusProcedure is the fully-qualified name of the
 	// ControlPlaneService's GetConfigStatus RPC.
 	ControlPlaneServiceGetConfigStatusProcedure = "/controlplane.v1.ControlPlaneService/GetConfigStatus"
+	// ControlPlaneServiceValidateConfigProcedure is the fully-qualified name of the
+	// ControlPlaneService's ValidateConfig RPC.
+	ControlPlaneServiceValidateConfigProcedure = "/controlplane.v1.ControlPlaneService/ValidateConfig"
+	// ControlPlaneServiceSaveConfigProcedure is the fully-qualified name of the ControlPlaneService's
+	// SaveConfig RPC.
+	ControlPlaneServiceSaveConfigProcedure = "/controlplane.v1.ControlPlaneService/SaveConfig"
+	// ControlPlaneServiceListConfigRevisionsProcedure is the fully-qualified name of the
+	// ControlPlaneService's ListConfigRevisions RPC.
+	ControlPlaneServiceListConfigRevisionsProcedure = "/controlplane.v1.ControlPlaneService/ListConfigRevisions"
+	// ControlPlaneServiceRestoreConfigRevisionProcedure is the fully-qualified name of the
+	// ControlPlaneService's RestoreConfigRevision RPC.
+	ControlPlaneServiceRestoreConfigRevisionProcedure = "/controlplane.v1.ControlPlaneService/RestoreConfigRevision"
 	// ControlPlaneServiceGetSystemInfoProcedure is the fully-qualified name of the
 	// ControlPlaneService's GetSystemInfo RPC.
 	ControlPlaneServiceGetSystemInfoProcedure = "/controlplane.v1.ControlPlaneService/GetSystemInfo"
@@ -105,6 +117,10 @@ type ControlPlaneServiceClient interface {
 	// resource metrics (CPU, memory, disk, temperature).
 	GetMachineVitals(context.Context, *connect.Request[v1.GetMachineVitalsRequest]) (*connect.Response[v1.GetMachineVitalsResponse], error)
 	GetConfigStatus(context.Context, *connect.Request[v1.GetConfigStatusRequest]) (*connect.Response[v1.GetConfigStatusResponse], error)
+	ValidateConfig(context.Context, *connect.Request[v1.ValidateConfigRequest]) (*connect.Response[v1.ValidateConfigResponse], error)
+	SaveConfig(context.Context, *connect.Request[v1.SaveConfigRequest]) (*connect.Response[v1.SaveConfigResponse], error)
+	ListConfigRevisions(context.Context, *connect.Request[v1.ListConfigRevisionsRequest]) (*connect.Response[v1.ListConfigRevisionsResponse], error)
+	RestoreConfigRevision(context.Context, *connect.Request[v1.RestoreConfigRevisionRequest]) (*connect.Response[v1.RestoreConfigRevisionResponse], error)
 	GetSystemInfo(context.Context, *connect.Request[v1.GetSystemInfoRequest]) (*connect.Response[v1.GetSystemInfoResponse], error)
 }
 
@@ -203,6 +219,30 @@ func NewControlPlaneServiceClient(httpClient connect.HTTPClient, baseURL string,
 			connect.WithSchema(controlPlaneServiceMethods.ByName("GetConfigStatus")),
 			connect.WithClientOptions(opts...),
 		),
+		validateConfig: connect.NewClient[v1.ValidateConfigRequest, v1.ValidateConfigResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceValidateConfigProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("ValidateConfig")),
+			connect.WithClientOptions(opts...),
+		),
+		saveConfig: connect.NewClient[v1.SaveConfigRequest, v1.SaveConfigResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceSaveConfigProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("SaveConfig")),
+			connect.WithClientOptions(opts...),
+		),
+		listConfigRevisions: connect.NewClient[v1.ListConfigRevisionsRequest, v1.ListConfigRevisionsResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceListConfigRevisionsProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("ListConfigRevisions")),
+			connect.WithClientOptions(opts...),
+		),
+		restoreConfigRevision: connect.NewClient[v1.RestoreConfigRevisionRequest, v1.RestoreConfigRevisionResponse](
+			httpClient,
+			baseURL+ControlPlaneServiceRestoreConfigRevisionProcedure,
+			connect.WithSchema(controlPlaneServiceMethods.ByName("RestoreConfigRevision")),
+			connect.WithClientOptions(opts...),
+		),
 		getSystemInfo: connect.NewClient[v1.GetSystemInfoRequest, v1.GetSystemInfoResponse](
 			httpClient,
 			baseURL+ControlPlaneServiceGetSystemInfoProcedure,
@@ -228,6 +268,10 @@ type controlPlaneServiceClient struct {
 	getHostResourceSamples *connect.Client[v1.GetHostResourceSamplesRequest, v1.GetHostResourceSamplesResponse]
 	getMachineVitals       *connect.Client[v1.GetMachineVitalsRequest, v1.GetMachineVitalsResponse]
 	getConfigStatus        *connect.Client[v1.GetConfigStatusRequest, v1.GetConfigStatusResponse]
+	validateConfig         *connect.Client[v1.ValidateConfigRequest, v1.ValidateConfigResponse]
+	saveConfig             *connect.Client[v1.SaveConfigRequest, v1.SaveConfigResponse]
+	listConfigRevisions    *connect.Client[v1.ListConfigRevisionsRequest, v1.ListConfigRevisionsResponse]
+	restoreConfigRevision  *connect.Client[v1.RestoreConfigRevisionRequest, v1.RestoreConfigRevisionResponse]
 	getSystemInfo          *connect.Client[v1.GetSystemInfoRequest, v1.GetSystemInfoResponse]
 }
 
@@ -301,6 +345,26 @@ func (c *controlPlaneServiceClient) GetConfigStatus(ctx context.Context, req *co
 	return c.getConfigStatus.CallUnary(ctx, req)
 }
 
+// ValidateConfig calls controlplane.v1.ControlPlaneService.ValidateConfig.
+func (c *controlPlaneServiceClient) ValidateConfig(ctx context.Context, req *connect.Request[v1.ValidateConfigRequest]) (*connect.Response[v1.ValidateConfigResponse], error) {
+	return c.validateConfig.CallUnary(ctx, req)
+}
+
+// SaveConfig calls controlplane.v1.ControlPlaneService.SaveConfig.
+func (c *controlPlaneServiceClient) SaveConfig(ctx context.Context, req *connect.Request[v1.SaveConfigRequest]) (*connect.Response[v1.SaveConfigResponse], error) {
+	return c.saveConfig.CallUnary(ctx, req)
+}
+
+// ListConfigRevisions calls controlplane.v1.ControlPlaneService.ListConfigRevisions.
+func (c *controlPlaneServiceClient) ListConfigRevisions(ctx context.Context, req *connect.Request[v1.ListConfigRevisionsRequest]) (*connect.Response[v1.ListConfigRevisionsResponse], error) {
+	return c.listConfigRevisions.CallUnary(ctx, req)
+}
+
+// RestoreConfigRevision calls controlplane.v1.ControlPlaneService.RestoreConfigRevision.
+func (c *controlPlaneServiceClient) RestoreConfigRevision(ctx context.Context, req *connect.Request[v1.RestoreConfigRevisionRequest]) (*connect.Response[v1.RestoreConfigRevisionResponse], error) {
+	return c.restoreConfigRevision.CallUnary(ctx, req)
+}
+
 // GetSystemInfo calls controlplane.v1.ControlPlaneService.GetSystemInfo.
 func (c *controlPlaneServiceClient) GetSystemInfo(ctx context.Context, req *connect.Request[v1.GetSystemInfoRequest]) (*connect.Response[v1.GetSystemInfoResponse], error) {
 	return c.getSystemInfo.CallUnary(ctx, req)
@@ -331,6 +395,10 @@ type ControlPlaneServiceHandler interface {
 	// resource metrics (CPU, memory, disk, temperature).
 	GetMachineVitals(context.Context, *connect.Request[v1.GetMachineVitalsRequest]) (*connect.Response[v1.GetMachineVitalsResponse], error)
 	GetConfigStatus(context.Context, *connect.Request[v1.GetConfigStatusRequest]) (*connect.Response[v1.GetConfigStatusResponse], error)
+	ValidateConfig(context.Context, *connect.Request[v1.ValidateConfigRequest]) (*connect.Response[v1.ValidateConfigResponse], error)
+	SaveConfig(context.Context, *connect.Request[v1.SaveConfigRequest]) (*connect.Response[v1.SaveConfigResponse], error)
+	ListConfigRevisions(context.Context, *connect.Request[v1.ListConfigRevisionsRequest]) (*connect.Response[v1.ListConfigRevisionsResponse], error)
+	RestoreConfigRevision(context.Context, *connect.Request[v1.RestoreConfigRevisionRequest]) (*connect.Response[v1.RestoreConfigRevisionResponse], error)
 	GetSystemInfo(context.Context, *connect.Request[v1.GetSystemInfoRequest]) (*connect.Response[v1.GetSystemInfoResponse], error)
 }
 
@@ -425,6 +493,30 @@ func NewControlPlaneServiceHandler(svc ControlPlaneServiceHandler, opts ...conne
 		connect.WithSchema(controlPlaneServiceMethods.ByName("GetConfigStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
+	controlPlaneServiceValidateConfigHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceValidateConfigProcedure,
+		svc.ValidateConfig,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("ValidateConfig")),
+		connect.WithHandlerOptions(opts...),
+	)
+	controlPlaneServiceSaveConfigHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceSaveConfigProcedure,
+		svc.SaveConfig,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("SaveConfig")),
+		connect.WithHandlerOptions(opts...),
+	)
+	controlPlaneServiceListConfigRevisionsHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceListConfigRevisionsProcedure,
+		svc.ListConfigRevisions,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("ListConfigRevisions")),
+		connect.WithHandlerOptions(opts...),
+	)
+	controlPlaneServiceRestoreConfigRevisionHandler := connect.NewUnaryHandler(
+		ControlPlaneServiceRestoreConfigRevisionProcedure,
+		svc.RestoreConfigRevision,
+		connect.WithSchema(controlPlaneServiceMethods.ByName("RestoreConfigRevision")),
+		connect.WithHandlerOptions(opts...),
+	)
 	controlPlaneServiceGetSystemInfoHandler := connect.NewUnaryHandler(
 		ControlPlaneServiceGetSystemInfoProcedure,
 		svc.GetSystemInfo,
@@ -461,6 +553,14 @@ func NewControlPlaneServiceHandler(svc ControlPlaneServiceHandler, opts ...conne
 			controlPlaneServiceGetMachineVitalsHandler.ServeHTTP(w, r)
 		case ControlPlaneServiceGetConfigStatusProcedure:
 			controlPlaneServiceGetConfigStatusHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceValidateConfigProcedure:
+			controlPlaneServiceValidateConfigHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceSaveConfigProcedure:
+			controlPlaneServiceSaveConfigHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceListConfigRevisionsProcedure:
+			controlPlaneServiceListConfigRevisionsHandler.ServeHTTP(w, r)
+		case ControlPlaneServiceRestoreConfigRevisionProcedure:
+			controlPlaneServiceRestoreConfigRevisionHandler.ServeHTTP(w, r)
 		case ControlPlaneServiceGetSystemInfoProcedure:
 			controlPlaneServiceGetSystemInfoHandler.ServeHTTP(w, r)
 		default:
@@ -526,6 +626,22 @@ func (UnimplementedControlPlaneServiceHandler) GetMachineVitals(context.Context,
 
 func (UnimplementedControlPlaneServiceHandler) GetConfigStatus(context.Context, *connect.Request[v1.GetConfigStatusRequest]) (*connect.Response[v1.GetConfigStatusResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.GetConfigStatus is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) ValidateConfig(context.Context, *connect.Request[v1.ValidateConfigRequest]) (*connect.Response[v1.ValidateConfigResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.ValidateConfig is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) SaveConfig(context.Context, *connect.Request[v1.SaveConfigRequest]) (*connect.Response[v1.SaveConfigResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.SaveConfig is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) ListConfigRevisions(context.Context, *connect.Request[v1.ListConfigRevisionsRequest]) (*connect.Response[v1.ListConfigRevisionsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.ListConfigRevisions is not implemented"))
+}
+
+func (UnimplementedControlPlaneServiceHandler) RestoreConfigRevision(context.Context, *connect.Request[v1.RestoreConfigRevisionRequest]) (*connect.Response[v1.RestoreConfigRevisionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("controlplane.v1.ControlPlaneService.RestoreConfigRevision is not implemented"))
 }
 
 func (UnimplementedControlPlaneServiceHandler) GetSystemInfo(context.Context, *connect.Request[v1.GetSystemInfoRequest]) (*connect.Response[v1.GetSystemInfoResponse], error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -257,6 +257,9 @@ func toProtoModule(module *debug.Module) *controlplanev1.Module {
 }
 
 func (s *Server) ListRunnerSets(_ context.Context, _ *connect.Request[controlplanev1.ListRunnerSetsRequest]) (*connect.Response[controlplanev1.ListRunnerSetsResponse], error) {
+	if s.managementService == nil {
+		return connect.NewResponse(&controlplanev1.ListRunnerSetsResponse{}), nil
+	}
 	views := s.managementService.ListRunnerSets()
 	sets := make([]*controlplanev1.RunnerSet, 0, len(views))
 	for _, v := range views {
@@ -285,6 +288,9 @@ func (s *Server) ListRunnerSets(_ context.Context, _ *connect.Request[controlpla
 }
 
 func (s *Server) ListJobRecords(_ context.Context, req *connect.Request[controlplanev1.ListJobRecordsRequest]) (*connect.Response[controlplanev1.ListJobRecordsResponse], error) {
+	if s.managementService == nil {
+		return connect.NewResponse(&controlplanev1.ListJobRecordsResponse{}), nil
+	}
 	cursor, _ := strconv.Atoi(req.Msg.Cursor)
 	filter := management.JobFilter{
 		Status:     req.Msg.Status,
@@ -315,6 +321,9 @@ func (s *Server) ListJobRecords(_ context.Context, req *connect.Request[controlp
 }
 
 func (s *Server) GetJobDetail(_ context.Context, req *connect.Request[controlplanev1.GetJobDetailRequest]) (*connect.Response[controlplanev1.GetJobDetailResponse], error) {
+	if s.managementService == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("job record was not found"))
+	}
 	job, err := s.managementService.GetJobRecord(req.Msg.Id)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("job record was not found"))
@@ -323,6 +332,9 @@ func (s *Server) GetJobDetail(_ context.Context, req *connect.Request[controlpla
 }
 
 func (s *Server) GetJobLogs(_ context.Context, req *connect.Request[controlplanev1.GetJobLogsRequest]) (*connect.Response[controlplanev1.GetJobLogsResponse], error) {
+	if s.managementService == nil {
+		return connect.NewResponse(&controlplanev1.GetJobLogsResponse{}), nil
+	}
 	logs, next := s.managementService.GetJobLogs(req.Msg.JobId, req.Msg.AfterSequence, int(req.Msg.PageSize))
 	lines := make([]*controlplanev1.JobLogLine, 0, len(logs))
 	for _, line := range logs {
@@ -336,6 +348,9 @@ func (s *Server) GetJobLogs(_ context.Context, req *connect.Request[controlplane
 }
 
 func (s *Server) GetJobResourceSamples(_ context.Context, req *connect.Request[controlplanev1.GetJobResourceSamplesRequest]) (*connect.Response[controlplanev1.GetJobResourceSamplesResponse], error) {
+	if s.managementService == nil {
+		return connect.NewResponse(&controlplanev1.GetJobResourceSamplesResponse{}), nil
+	}
 	samples := s.managementService.GetJobSamples(req.Msg.JobId)
 	result := make([]*controlplanev1.ResourceSample, 0, len(samples))
 	for _, sample := range samples {
@@ -345,6 +360,9 @@ func (s *Server) GetJobResourceSamples(_ context.Context, req *connect.Request[c
 }
 
 func (s *Server) GetHostResourceSamples(_ context.Context, req *connect.Request[controlplanev1.GetHostResourceSamplesRequest]) (*connect.Response[controlplanev1.GetHostResourceSamplesResponse], error) {
+	if s.managementService == nil {
+		return connect.NewResponse(&controlplanev1.GetHostResourceSamplesResponse{}), nil
+	}
 	to := time.Now()
 	from := to.Add(-time.Hour)
 	if req.Msg.From != nil {
@@ -447,6 +465,13 @@ func (s *Server) GetConfigStatus(_ context.Context, _ *connect.Request[controlpl
 	if s.configState == nil {
 		return connect.NewResponse(&controlplanev1.GetConfigStatusResponse{}), nil
 	}
+	return connect.NewResponse(s.configStatusResponse()), nil
+}
+
+func (s *Server) configStatusResponse() *controlplanev1.GetConfigStatusResponse {
+	if s.configState == nil {
+		return &controlplanev1.GetConfigStatusResponse{}
+	}
 	snapshot := s.configState.Get()
 	response := &controlplanev1.GetConfigStatusResponse{
 		Path:             snapshot.Path,
@@ -457,11 +482,92 @@ func (s *Server) GetConfigStatus(_ context.Context, _ *connect.Request[controlpl
 		ValidationErrors: snapshot.ValidationErrors,
 		ActiveYaml:       snapshot.ActiveYAML,
 		DiskYaml:         snapshot.DiskYAML,
+		RestartCommands: []string{
+			"brew services restart elastic-fruit-runner",
+			"docker compose restart elastic-fruit-runner",
+			"sudo systemctl restart elastic-fruit-runner",
+		},
 	}
 	if snapshot.DiskModifiedAt != nil {
 		response.DiskModifiedAt = timestamppb.New(*snapshot.DiskModifiedAt)
 	}
-	return connect.NewResponse(response), nil
+	return response
+}
+
+func (s *Server) ValidateConfig(_ context.Context, req *connect.Request[controlplanev1.ValidateConfigRequest]) (*connect.Response[controlplanev1.ValidateConfigResponse], error) {
+	if s.configState == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("config service is unavailable"))
+	}
+	result := s.configState.Validate([]byte(req.Msg.Yaml))
+	return connect.NewResponse(toProtoValidation(result)), nil
+}
+
+func (s *Server) SaveConfig(ctx context.Context, req *connect.Request[controlplanev1.SaveConfigRequest]) (*connect.Response[controlplanev1.SaveConfigResponse], error) {
+	if err := s.requireCSRF(ctx, req.Header()); err != nil {
+		return nil, err
+	}
+	if s.configState == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("config service is unavailable"))
+	}
+	validation := s.configState.Validate([]byte(req.Msg.Yaml))
+	if len(validation.Errors) > 0 {
+		return connect.NewResponse(&controlplanev1.SaveConfigResponse{Validation: toProtoValidation(validation)}), nil
+	}
+	if len(validation.Warnings) > 0 && !req.Msg.ConfirmWarnings {
+		return connect.NewResponse(&controlplanev1.SaveConfigResponse{Validation: toProtoValidation(validation)}), nil
+	}
+	result, err := s.configState.Save([]byte(req.Msg.Yaml), "console")
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&controlplanev1.SaveConfigResponse{
+		Validation: toProtoValidation(result),
+		Status:     s.configStatusResponse(),
+	}), nil
+}
+
+func (s *Server) ListConfigRevisions(_ context.Context, _ *connect.Request[controlplanev1.ListConfigRevisionsRequest]) (*connect.Response[controlplanev1.ListConfigRevisionsResponse], error) {
+	if s.configState == nil {
+		return connect.NewResponse(&controlplanev1.ListConfigRevisionsResponse{}), nil
+	}
+	revisions, err := s.configState.Revisions()
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	result := make([]*controlplanev1.ConfigRevision, 0, len(revisions))
+	for _, revision := range revisions {
+		result = append(result, &controlplanev1.ConfigRevision{
+			Id:         revision.ID,
+			CreatedAt:  timestamppb.New(revision.CreatedAt),
+			Source:     revision.Source,
+			ConfigHash: revision.Hash,
+		})
+	}
+	return connect.NewResponse(&controlplanev1.ListConfigRevisionsResponse{Revisions: result}), nil
+}
+
+func (s *Server) RestoreConfigRevision(ctx context.Context, req *connect.Request[controlplanev1.RestoreConfigRevisionRequest]) (*connect.Response[controlplanev1.RestoreConfigRevisionResponse], error) {
+	if err := s.requireCSRF(ctx, req.Header()); err != nil {
+		return nil, err
+	}
+	if s.configState == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("config service is unavailable"))
+	}
+	if err := s.configState.Restore(req.Msg.Id); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	return connect.NewResponse(&controlplanev1.RestoreConfigRevisionResponse{Status: s.configStatusResponse()}), nil
+}
+
+func toProtoValidation(result config.ValidationResult) *controlplanev1.ValidateConfigResponse {
+	response := &controlplanev1.ValidateConfigResponse{NormalizedYaml: result.Normalized}
+	for _, issue := range result.Errors {
+		response.Errors = append(response.Errors, &controlplanev1.ConfigValidationIssue{Path: issue.Path, Message: issue.Message})
+	}
+	for _, issue := range result.Warnings {
+		response.Warnings = append(response.Warnings, &controlplanev1.ConfigValidationIssue{Path: issue.Path, Message: issue.Message})
+	}
+	return response
 }
 
 func (s *Server) GetSystemInfo(_ context.Context, _ *connect.Request[controlplanev1.GetSystemInfoRequest]) (*connect.Response[controlplanev1.GetSystemInfoResponse], error) {
@@ -557,6 +663,17 @@ func (s *Server) sessionFromHeader(ctx context.Context, header http.Header) (aut
 		return auth.Session{}, auth.ErrSessionNotFound
 	}
 	return s.authService.FindSession(ctx, cookie.Value)
+}
+
+func (s *Server) requireCSRF(ctx context.Context, header http.Header) error {
+	session, err := s.sessionFromHeader(ctx, header)
+	if err != nil {
+		return connect.NewError(connect.CodeUnauthenticated, auth.ErrSessionNotFound)
+	}
+	if header.Get("X-CSRF-Token") != session.CSRFToken {
+		return connect.NewError(connect.CodePermissionDenied, errors.New("CSRF token is not valid"))
+	}
+	return nil
 }
 
 func setSessionCookie(header http.Header, session auth.Session) {

--- a/internal/configstate/service.go
+++ b/internal/configstate/service.go
@@ -3,9 +3,11 @@ package configstate
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,17 +43,20 @@ type Service struct {
 	activeHash     string
 	activeYAML     string
 	activeLoadedAt time.Time
+	db             *sql.DB
 
 	mu       sync.RWMutex
 	snapshot Snapshot
 }
 
 // New creates a config state service from the config loaded at startup.
-func New(cfg *config.Config, loadedAt time.Time) *Service {
+func New(cfg *config.Config, loadedAt time.Time, databasePath ...string) *Service {
 	activeData := cfg.LoadedYAML
 	activeHash := cfg.LoadedHash
 	if len(activeData) == 0 {
 		activeData, _ = yaml.Marshal(cfg)
+		activeHash = hash(activeData)
+	} else if activeHash == "" {
 		activeHash = hash(activeData)
 	}
 	service := &Service{
@@ -60,8 +65,39 @@ func New(cfg *config.Config, loadedAt time.Time) *Service {
 		activeYAML:     redactYAML(activeData),
 		activeLoadedAt: loadedAt,
 	}
+	if len(databasePath) > 0 && databasePath[0] != "" {
+		if db, err := openRevisionDB(databasePath[0]); err == nil {
+			service.db = db
+			if len(cfg.LoadedYAML) > 0 {
+				_ = service.saveRevision(cfg.LoadedYAML, "startup", true)
+			}
+		}
+	}
 	service.refresh()
 	return service
+}
+
+// NewForConfigMode creates state when no valid runtime config exists.
+func NewForConfigMode(path, databasePath string, loadedAt time.Time) *Service {
+	service := &Service{
+		path:           path,
+		activeLoadedAt: loadedAt,
+	}
+	if databasePath != "" {
+		if db, err := openRevisionDB(databasePath); err == nil {
+			service.db = db
+		}
+	}
+	service.refresh()
+	return service
+}
+
+// Close closes config revision storage.
+func (s *Service) Close() error {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.Close()
 }
 
 // Start refreshes disk state until the context ends.
@@ -118,10 +154,12 @@ func (s *Service) refresh() {
 		next.DiskModifiedAt = &modifiedAt
 	}
 
-	var document yaml.Node
-	if err := yaml.Unmarshal(data, &document); err != nil {
+	validation := config.ValidateYAML(data)
+	if len(validation.Errors) > 0 {
 		next.State = StateDiskInvalid
-		next.ValidationErrors = []string{fmt.Sprintf("parse config file %s: %v", s.path, err)}
+		for _, issue := range validation.Errors {
+			next.ValidationErrors = append(next.ValidationErrors, issue.String())
+		}
 		s.set(next)
 		return
 	}
@@ -146,7 +184,13 @@ func hash(data []byte) string {
 func redactYAML(data []byte) string {
 	var document yaml.Node
 	if err := yaml.Unmarshal(data, &document); err != nil {
-		return ""
+		lines := strings.Split(string(data), "\n")
+		for index, line := range lines {
+			if separator := strings.Index(line, "pat_token:"); separator >= 0 {
+				lines[index] = line[:separator] + "pat_token: ********"
+			}
+		}
+		return strings.Join(lines, "\n")
 	}
 	redactNode(&document)
 	redacted, err := yaml.Marshal(&document)

--- a/internal/configstate/storage.go
+++ b/internal/configstate/storage.go
@@ -1,0 +1,312 @@
+package configstate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+	// Register the SQLite driver.
+	_ "modernc.org/sqlite"
+
+	"github.com/boring-design/elastic-fruit-runner/config"
+)
+
+type Revision struct {
+	ID        int64
+	CreatedAt time.Time
+	Source    string
+	Hash      string
+}
+
+func openRevisionDB(path string) (*sql.DB, error) {
+	if path != ":memory:" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			return nil, fmt.Errorf("create config revision directory %s: %w", filepath.Dir(path), err)
+		}
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open config revision database %s: %w", path, err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(context.Background(), `
+		PRAGMA busy_timeout=5000;
+		CREATE TABLE IF NOT EXISTS config_revisions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			created_at DATETIME NOT NULL,
+			source TEXT NOT NULL,
+			config_hash TEXT NOT NULL,
+			config_yaml BLOB NOT NULL,
+			active INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE INDEX IF NOT EXISTS idx_config_revisions_created_at
+		ON config_revisions (created_at DESC);
+	`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create config revision tables: %w", err)
+	}
+	if path != ":memory:" {
+		_ = os.Chmod(path, 0o600)
+	}
+	return db, nil
+}
+
+func LoadLastActive(databasePath string) ([]byte, error) {
+	db, err := openRevisionDB(databasePath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	var data []byte
+	err = db.QueryRowContext(context.Background(), `
+		SELECT config_yaml FROM config_revisions
+		WHERE active = 1 ORDER BY created_at DESC LIMIT 1`).Scan(&data)
+	if err != nil {
+		return nil, fmt.Errorf("read last active config: %w", err)
+	}
+	return data, nil
+}
+
+func (s *Service) Validate(data []byte) config.ValidationResult {
+	current, _ := os.ReadFile(s.path)
+	merged, err := mergeMaskedSecrets(data, current)
+	if err != nil {
+		return config.ValidationResult{
+			Errors: []config.ValidationIssue{{Path: "$", Message: err.Error()}},
+		}
+	}
+	return safeValidation(config.ValidateYAML(merged))
+}
+
+func (s *Service) Save(data []byte, source string) (config.ValidationResult, error) {
+	current, _ := os.ReadFile(s.path)
+	merged, err := mergeMaskedSecrets(data, current)
+	if err != nil {
+		return config.ValidationResult{}, err
+	}
+	result := config.ValidateYAML(merged)
+	if len(result.Errors) > 0 {
+		return safeValidation(result), nil
+	}
+	if s.path == "" {
+		return result, errors.New("config file path is not set")
+	}
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return safeValidation(result), fmt.Errorf("create config directory %s: %w", dir, err)
+	}
+	file, err := os.CreateTemp(dir, ".config-save")
+	if err != nil {
+		return result, fmt.Errorf("create temporary config in %s: %w", dir, err)
+	}
+	tempPath := file.Name()
+	defer os.Remove(tempPath)
+	if err := file.Chmod(0o600); err != nil {
+		file.Close()
+		return result, fmt.Errorf("set temporary config permissions: %w", err)
+	}
+	if _, err := file.Write(merged); err != nil {
+		file.Close()
+		return result, fmt.Errorf("write temporary config: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return result, fmt.Errorf("sync temporary config: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return result, fmt.Errorf("close temporary config: %w", err)
+	}
+	if err := os.Rename(tempPath, s.path); err != nil {
+		return result, fmt.Errorf("replace config file %s: %w", s.path, err)
+	}
+	if err := os.Chmod(s.path, 0o600); err != nil {
+		return result, fmt.Errorf("set config file permissions %s: %w", s.path, err)
+	}
+	if err := s.saveRevision(merged, source, false); err != nil {
+		return result, err
+	}
+	s.refresh()
+	return safeValidation(result), nil
+}
+
+func safeValidation(result config.ValidationResult) config.ValidationResult {
+	result.Config = nil
+	if result.Normalized != "" {
+		result.Normalized = redactYAML([]byte(result.Normalized))
+	}
+	return result
+}
+
+func (s *Service) Revisions() ([]Revision, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(context.Background(), `
+		SELECT id, created_at, source, config_hash
+		FROM config_revisions ORDER BY created_at DESC LIMIT 10`)
+	if err != nil {
+		return nil, fmt.Errorf("list config revisions: %w", err)
+	}
+	defer rows.Close()
+	var revisions []Revision
+	for rows.Next() {
+		var revision Revision
+		if err := rows.Scan(&revision.ID, &revision.CreatedAt, &revision.Source, &revision.Hash); err != nil {
+			return nil, fmt.Errorf("read config revision: %w", err)
+		}
+		revisions = append(revisions, revision)
+	}
+	return revisions, nil
+}
+
+func (s *Service) Restore(revisionID int64) error {
+	if s.db == nil {
+		return errors.New("config revision storage is unavailable")
+	}
+	var data []byte
+	if err := s.db.QueryRowContext(context.Background(), `
+		SELECT config_yaml FROM config_revisions WHERE id = ?`, revisionID).Scan(&data); err != nil {
+		return fmt.Errorf("read config revision %d: %w", revisionID, err)
+	}
+	result, err := s.Save(data, "restore")
+	if err != nil {
+		return err
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("revision %d is not valid: %s", revisionID, result.Errors[0].String())
+	}
+	return nil
+}
+
+func (s *Service) saveRevision(data []byte, source string, active bool) error {
+	if s.db == nil {
+		return nil
+	}
+	tx, err := s.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("start config revision save: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	ctx := context.Background()
+	if active {
+		if _, err := tx.ExecContext(ctx, `UPDATE config_revisions SET active = 0`); err != nil {
+			return fmt.Errorf("clear active config revision: %w", err)
+		}
+	}
+	activeValue := 0
+	if active {
+		activeValue = 1
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO config_revisions (created_at, source, config_hash, config_yaml, active)
+		VALUES (?, ?, ?, ?, ?)`,
+		time.Now(), source, hash(data), data, activeValue,
+	); err != nil {
+		return fmt.Errorf("insert config revision: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM config_revisions WHERE id NOT IN (
+			SELECT id FROM config_revisions ORDER BY created_at DESC LIMIT 10
+		)`); err != nil {
+		return fmt.Errorf("trim config revisions: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit config revision: %w", err)
+	}
+	return nil
+}
+
+func mergeMaskedSecrets(draft, current []byte) ([]byte, error) {
+	var draftNode yaml.Node
+	if err := yaml.Unmarshal(draft, &draftNode); err != nil {
+		return nil, fmt.Errorf("parse edited config: %w", err)
+	}
+	if len(current) == 0 {
+		return draft, nil
+	}
+	var currentNode yaml.Node
+	if !parseYAML(current, &currentNode) {
+		return mergeMaskedLines(draft, current), nil
+	}
+	mergeSecretNodes(&draftNode, &currentNode)
+	result, err := yaml.Marshal(&draftNode)
+	if err != nil {
+		return nil, fmt.Errorf("encode edited config: %w", err)
+	}
+	return result, nil
+}
+
+func parseYAML(data []byte, node *yaml.Node) bool {
+	return yaml.Unmarshal(data, node) == nil
+}
+
+func mergeMaskedLines(draft, current []byte) []byte {
+	var secrets []string
+	for _, line := range strings.Split(string(current), "\n") {
+		if index := strings.Index(line, "pat_token:"); index >= 0 {
+			secrets = append(secrets, strings.TrimSpace(line[index+len("pat_token:"):]))
+		}
+	}
+	lines := strings.Split(string(draft), "\n")
+	secretIndex := 0
+	for index, line := range lines {
+		keyIndex := strings.Index(line, "pat_token:")
+		if keyIndex < 0 {
+			continue
+		}
+		value := strings.TrimSpace(line[keyIndex+len("pat_token:"):])
+		if (value == "" || strings.Trim(value, "*\"'") == "") && secretIndex < len(secrets) {
+			lines[index] = line[:keyIndex] + "pat_token: " + secrets[secretIndex]
+		}
+		secretIndex++
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func mergeSecretNodes(draft, current *yaml.Node) {
+	if draft.Kind != current.Kind {
+		return
+	}
+	if draft.Kind == yaml.MappingNode {
+		currentValues := make(map[string]*yaml.Node)
+		for index := 0; index+1 < len(current.Content); index += 2 {
+			currentValues[current.Content[index].Value] = current.Content[index+1]
+		}
+		for index := 0; index+1 < len(draft.Content); index += 2 {
+			key := draft.Content[index].Value
+			draftValue := draft.Content[index+1]
+			currentValue := currentValues[key]
+			if currentValue == nil {
+				continue
+			}
+			if key == "pat_token" && (draftValue.Value == "" || strings.Trim(draftValue.Value, "*") == "") {
+				draft.Content[index+1] = copyNode(currentValue)
+				continue
+			}
+			mergeSecretNodes(draftValue, currentValue)
+		}
+		return
+	}
+	for index := range draft.Content {
+		if index < len(current.Content) {
+			mergeSecretNodes(draft.Content[index], current.Content[index])
+		}
+	}
+}
+
+func copyNode(node *yaml.Node) *yaml.Node {
+	result := *node
+	result.Content = make([]*yaml.Node, len(node.Content))
+	for index, child := range node.Content {
+		result.Content[index] = copyNode(child)
+	}
+	return &result
+}

--- a/proto/controlplane/v1/controlplane.proto
+++ b/proto/controlplane/v1/controlplane.proto
@@ -43,6 +43,14 @@ service ControlPlaneService {
 
   rpc GetConfigStatus(GetConfigStatusRequest) returns (GetConfigStatusResponse);
 
+  rpc ValidateConfig(ValidateConfigRequest) returns (ValidateConfigResponse);
+
+  rpc SaveConfig(SaveConfigRequest) returns (SaveConfigResponse);
+
+  rpc ListConfigRevisions(ListConfigRevisionsRequest) returns (ListConfigRevisionsResponse);
+
+  rpc RestoreConfigRevision(RestoreConfigRevisionRequest) returns (RestoreConfigRevisionResponse);
+
   rpc GetSystemInfo(GetSystemInfoRequest) returns (GetSystemInfoResponse);
 }
 
@@ -341,6 +349,53 @@ message GetConfigStatusResponse {
   repeated string validation_errors = 7;
   string active_yaml = 8;
   string disk_yaml = 9;
+  repeated string restart_commands = 10;
+}
+
+message ConfigValidationIssue {
+  string path = 1;
+  string message = 2;
+}
+
+message ValidateConfigRequest {
+  string yaml = 1;
+}
+
+message ValidateConfigResponse {
+  repeated ConfigValidationIssue errors = 1;
+  repeated ConfigValidationIssue warnings = 2;
+  string normalized_yaml = 3;
+}
+
+message SaveConfigRequest {
+  string yaml = 1;
+  bool confirm_warnings = 2;
+}
+
+message SaveConfigResponse {
+  ValidateConfigResponse validation = 1;
+  GetConfigStatusResponse status = 2;
+}
+
+message ConfigRevision {
+  int64 id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  string source = 3;
+  string config_hash = 4;
+}
+
+message ListConfigRevisionsRequest {}
+
+message ListConfigRevisionsResponse {
+  repeated ConfigRevision revisions = 1;
+}
+
+message RestoreConfigRevisionRequest {
+  int64 id = 1;
+}
+
+message RestoreConfigRevisionResponse {
+  GetConfigStatusResponse status = 1;
 }
 
 // System information


### PR DESCRIPTION
## Problem

Operators cannot safely validate, edit, recover, or compare the disk config from the console.

## Solution

Use one strict validator for startup and console actions, store the newest ten config revisions, and keep config changes manual until an operator restarts the service.

## Major Changes

- Validation
  - Check YAML, unknown fields, duplicate keys, required values, ranges, GitHub names, auth choice, PEM data, paths, CORS, and backend settings
- Config editing
  - Preserve masked secrets, validate before save, require warning confirmation, atomically write mode 0600, and show active versus disk diff
- Recovery
  - Start from the last active revision when disk config is invalid
  - Start config mode without controllers when no active revision exists
- Operations
  - List and restore the newest ten revisions and show external restart commands without adding a restart RPC

## Validation

- `make check`
- Dashboard build and lint
- Config mode, valid save, warning confirmation, mode 0600, manual restart, active hash, invalid disk fallback, secret masking, revision list, and five page browser checks

Closes #87
Tracked by #84