### PR TITLE
docs(console): finish delivery and operations guides

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,72 +1,24 @@
-# elastic-fruit-runner · Dashboard
+# Elastic Fruit Runner Console
 
-A terminal-style monitoring dashboard for [elastic-fruit-runner](../) — a GitHub Actions Runner Scale Set controller for Apple Silicon and Linux.
+The dashboard is the embedded operations console for one Elastic Fruit Runner daemon.
 
-## Overview
-
-The dashboard provides a real-time view of runner state, system health, and job history. It is designed for engineers who want dense, actionable information at a glance, with a dark monospace aesthetic inspired by terminal UIs.
-
-### Features
-
-- **Runner Brain** — a pixel-art mascot that reflects the runner's current mood (`STANDING BY`, `PROCESSING`, `SPINNING UP`, `RESTING`) with animated expressions
-- **Runner Capacity** — overall and per-set utilization bars, average job duration, and success rate
-- **System Vitals** — live-fluctuating CPU, memory, disk, and temperature readings
-- **Connection Status** — GitHub org/repo target, auth mode, and last job timestamp
-- **Recent Jobs** — scrollable history of completed and running jobs with result and duration
-- **Responsive** — adapts from desktop (3-column) to tablet (2-column) to mobile (single-column)
-
-## Tech Stack
-
-| Layer | Choice |
-|-------|--------|
-| Framework | React 19 + TypeScript |
-| Build | Vite |
-| Styles | Tailwind CSS v4 + inline styles |
-| Font | Geist Mono Variable |
-| Data | Mock (ready to wire to a real API) |
+It provides Overview, Jobs, Runner Sets, Config, and System pages. Data comes from the Connect RPC service in the daemon.
 
 ## Development
 
-```bash
-# from the dashboard/ directory
-npm install
-npm run dev        # http://localhost:5173
-npm run build      # output in dist/
-npm run preview    # preview production build
+```sh
+pnpm install
+pnpm run dev
+pnpm run build
+pnpm run lint
 ```
 
-## Wiring to Real Data
+Set `VITE_API_BASE` only when the dashboard development server and daemon use different origins.
 
-All mock data lives in `src/mock.ts`. The type contracts are in `src/types.ts`.
+The production build is written to `dist` and embedded in the Go binary.
 
-When the daemon exposes an HTTP API, replace the imports in `src/App.tsx`:
+## Security
 
-```ts
-// Before (mock)
-import { daemonStatus, runnerSets, recentJobs } from './mock'
+The console uses a one time setup code, one admin password, an HttpOnly session cookie, and CSRF tokens for changes.
 
-// After (real API)
-const { daemonStatus, runnerSets, recentJobs } = await fetch('/api/status').then(r => r.json())
-```
-
-The data shape expected by the dashboard:
-
-```ts
-DaemonStatus   // buildInfo, startedAt, githubConnected, idleTimeout
-RunnerSet[]    // name, backend, image, labels, maxRunners, scope, runners[]
-JobRecord[]    // id, runnerName, runnerSetName, result, startedAt, completedAt
-```
-
-## Project Structure
-
-```
-src/
-├── App.tsx                  # main layout and all page-level components
-├── types.ts                 # shared TypeScript interfaces
-├── mock.ts                  # mock data (replace with real API calls)
-├── index.css                # global styles, CSS variables, responsive grid
-├── main.tsx                 # React entry point
-└── components/
-    ├── PixelPet.tsx         # animated pixel-art mascot (canvas-based)
-    └── SystemVitals.tsx     # CPU / memory / disk / temperature bars
-```
+Secret values are masked by the API. A masked PAT in the editor keeps the current disk value when saved.

--- a/doc-site/astro.config.mjs
+++ b/doc-site/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
 						{ slug: 'how-to/prevent-macos-sleep' },
 						{ slug: 'how-to/install-linux-docker' },
 						{ slug: 'how-to/configure-github-app' },
+						{ slug: 'how-to/use-console' },
 						{ slug: 'how-to/multiple-orgs-repos' },
 						{ slug: 'how-to/troubleshooting' },
 						{ slug: 'how-to/run-integration-tests' },

--- a/doc-site/src/content/docs/how-to/install-linux-docker.md
+++ b/doc-site/src/content/docs/how-to/install-linux-docker.md
@@ -33,6 +33,7 @@ orgs:
         platform: linux/amd64
 
 idle_timeout: 15m
+db_path: /var/lib/elastic-fruit-runner/jobs.db
 ```
 
 ```yaml
@@ -43,12 +44,17 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./config.yaml:/etc/elastic-fruit-runner/config.yaml:ro
+      - ./config.yaml:/etc/elastic-fruit-runner/config.yaml
+      - ./data:/var/lib/elastic-fruit-runner
+    ports:
+      - 127.0.0.1:8080:8080
 ```
 
 ```sh
 docker compose up -d
 ```
+
+Open `http://127.0.0.1:8080` and use the setup code from the container log. The config mount must be writable to use the editor. See [Use the operations console](/how-to/use-console/).
 
 ## Docker Compose with GitHub App auth
 
@@ -80,6 +86,7 @@ orgs:
         platform: linux/amd64
 
 idle_timeout: 15m
+db_path: /var/lib/elastic-fruit-runner/jobs.db
 ```
 
 ```yaml
@@ -90,8 +97,11 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./config.yaml:/etc/elastic-fruit-runner/config.yaml:ro
+      - ./config.yaml:/etc/elastic-fruit-runner/config.yaml
       - ./private-key.pem:/etc/efr/private-key.pem:ro
+      - ./data:/var/lib/elastic-fruit-runner
+    ports:
+      - 127.0.0.1:8080:8080
 ```
 
 ## How it works

--- a/doc-site/src/content/docs/how-to/install-macos.md
+++ b/doc-site/src/content/docs/how-to/install-macos.md
@@ -72,6 +72,8 @@ If the Mac is used as a dedicated runner host (e.g. a Mac mini or a MacBook with
 brew services start elastic-fruit-runner
 ```
 
+Open `http://127.0.0.1:8080` and use the setup code from the service log. See [Use the operations console](/how-to/use-console/).
+
 Check status:
 
 ```sh

--- a/doc-site/src/content/docs/how-to/use-console.md
+++ b/doc-site/src/content/docs/how-to/use-console.md
@@ -1,0 +1,100 @@
+---
+title: Use the operations console
+description: Set up, operate, and recover the Elastic Fruit Runner console.
+---
+
+The console is served by the daemon on `http://127.0.0.1:8080` by default. It manages one daemon and one host.
+
+## First login
+
+On the first start, the daemon writes a one time setup code to its local log. Open the console, enter that code, and set the admin password.
+
+The password is stored as a strong hash. Login uses an HttpOnly session cookie. The console never returns PAT values or private key contents.
+
+## Password recovery
+
+Stop the daemon, clear the local admin password, and start the daemon again:
+
+```sh
+elastic-fruit-runner reset-password --config /path/to/config.yaml
+```
+
+The next start writes a new setup code to the local log. Existing console sessions are removed.
+
+## Pages
+
+| Page | Purpose |
+|------|---------|
+| Overview | Current daemon, GitHub, runner, job, config, and host state |
+| Jobs | Job filters, GitHub Actions links, lifecycle times, logs, and resource history |
+| Runner Sets | Scope, backend, image, labels, capacity, connection state, and active runners |
+| Config | Active config, disk config, validation, editing, revisions, and restart commands |
+| System | Runtime details, storage use, current host state, and host history |
+
+Docker job data comes from container logs and Docker resource data.
+
+Tart job logs come from the runner process in the VM. Guest resource use is not available without a guest agent, so the console labels Tart allocation and host side values as estimates.
+
+## Edit config
+
+The active config is the version loaded when the daemon started. The disk config is the current file content.
+
+Saving follows this order:
+
+1. Parse YAML.
+2. Check unknown fields, duplicate keys, required values, ranges, names, auth choice, backend settings, paths, CORS, and private key PEM data.
+3. Stop when any error exists.
+4. Ask for confirmation when only warnings exist.
+5. Replace the disk file in one atomic operation.
+6. Set file permissions to `0600`.
+7. Save a revision.
+8. Show `Restart required`.
+
+Saving does not reload controllers and does not restart the daemon.
+
+Run the command that matches the installation:
+
+```sh
+brew services restart elastic-fruit-runner
+docker compose restart elastic-fruit-runner
+sudo systemctl restart elastic-fruit-runner
+```
+
+A restart can interrupt running jobs. Check the Jobs page before restarting.
+
+## Config recovery
+
+The daemon keeps the newest ten config revisions.
+
+If the disk config is invalid and an active revision exists, the daemon starts with the last active revision. The Config page reports `Disk config invalid`.
+
+If no active revision exists, the daemon starts in config mode on the default local address. Controllers do not start. Authentication and the Config page remain available.
+
+Restoring a revision only writes it to disk. A manual restart is still required.
+
+## Data history
+
+Host data is collected every five seconds. Raw samples remain available for twenty four hours. One minute summaries remain available for thirty days.
+
+Job records, job logs, job resource data, and host resource data share a ten GB limit. Cleanup removes data older than thirty days first. If storage is still above the limit, cleanup removes the oldest completed jobs until use is below nine GB. Running jobs are never removed.
+
+The System page shows the earliest available host sample.
+
+## Upgrade
+
+Before an upgrade, confirm that the current disk config is valid and note the active hash.
+
+After an upgrade:
+
+1. Open Overview and confirm GitHub connection state.
+2. Open Config and confirm the active and disk hashes.
+3. Open Jobs and confirm new work appears.
+4. Open System and confirm new host samples appear.
+
+An existing valid config becomes the first active revision after controllers initialize successfully.
+
+## Network access
+
+The daemon does not provide TLS. Keep the console on a trusted local network or place it behind a TLS reverse proxy.
+
+Every management RPC requires login. Config save, revision restore, and logout also require a valid CSRF token.

--- a/doc-site/src/content/docs/reference/cli.md
+++ b/doc-site/src/content/docs/reference/cli.md
@@ -43,3 +43,13 @@ Override log level via environment variable:
 ```sh
 LOG_LEVEL=debug elastic-fruit-runner
 ```
+
+## Reset the console password
+
+Stop the daemon before resetting the password:
+
+```sh
+elastic-fruit-runner reset-password --config /path/to/config.yaml
+```
+
+This removes the admin password and all console sessions. Start the daemon again and use the new setup code from the local log.

--- a/doc-site/src/content/docs/reference/configuration.md
+++ b/doc-site/src/content/docs/reference/configuration.md
@@ -70,6 +70,10 @@ log_level: info
 | `repos` | list | — | Repository-level runner set configurations |
 | `idle_timeout` | duration | `15m` | Time after which idle runners are reaped. Must be > 0 |
 | `log_level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `api_addr` | string | `:8080` | Console listen address |
+| `db_path` | string | local data directory | SQLite path for job, auth, and host data |
+| `log_path` | string | empty | Optional writable log path used for path validation |
+| `cors` | object | local defaults | Console CORS settings |
 
 At least one of `orgs` or `repos` must be configured.
 
@@ -157,3 +161,13 @@ Only one environment variable is supported:
 | `LOG_LEVEL` | `log_level` | Overrides the log level from config file |
 
 All other configuration must be done through the YAML config file.
+
+## Validation
+
+Startup, console validation, and console save use the same strict YAML validator. Unknown fields and duplicate keys are errors.
+
+Validation also checks runner set name uniqueness, auth choice, private key PEM data, API address, CORS values, writable paths, runner limits, and backend settings.
+
+GitHub connectivity is reported as a warning. It is not part of structural validation.
+
+See [Use the operations console](/how-to/use-console/) for save, revision, and recovery behavior.


### PR DESCRIPTION
## Problem

The existing dashboard guide describes removed mock data and decorative UI, while operators lack console setup, recovery, restart, retention, and backend guidance.

## Solution

Document the final console behavior and update installation, configuration, and CLI guidance for secure daily operation.

## Major Changes

- Console operations
  - Document first login, password recovery, pages, config save, manual restart, revisions, config mode, retention, upgrades, and network security
- Installation
  - Document the local console address and writable Docker config and data mounts
- Reference
  - Add strict validation behavior, console fields, and the password reset command
- Dashboard guide
  - Replace the old mock and pixel pet guide with the embedded Connect RPC console workflow

## Validation

- Documentation site build
- `make check`
- Real browser pass on all five pages and narrow layout

Closes #88
Tracked by #84