### PR TITLE
fix(console): complete operations acceptance

### DIFF
--- a/cmd/elastic-fruit-runner/main.go
+++ b/cmd/elastic-fruit-runner/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -144,6 +146,7 @@ func runDaemon() error {
 			Auth:         authService,
 			ConfigState:  configStateService,
 			DatabasePath: databasePath,
+			LogPath:      configLogPath(cfg),
 		},
 	)
 	httpServer := &http.Server{
@@ -225,8 +228,30 @@ func configureLogging(cfg *config.Config) error {
 		return fmt.Errorf("invalid log level %q: %w", cfg.LogLevel, err)
 	}
 
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	output := io.Writer(os.Stdout)
+	if cfg.LogPath != "" {
+		if err := os.MkdirAll(filepath.Dir(cfg.LogPath), 0o750); err != nil {
+			return fmt.Errorf("create log directory %s: %w", filepath.Dir(cfg.LogPath), err)
+		}
+		file, openErr := os.OpenFile(cfg.LogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if openErr != nil {
+			return fmt.Errorf("open log file %s: %w", cfg.LogPath, openErr)
+		}
+		if chmodErr := file.Chmod(0o600); chmodErr != nil {
+			_ = file.Close()
+			return fmt.Errorf("set log file permissions %s: %w", cfg.LogPath, chmodErr)
+		}
+		output = io.MultiWriter(os.Stdout, file)
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(output, &slog.HandlerOptions{
 		Level: logLevel,
 	})))
 	return nil
+}
+
+func configLogPath(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.LogPath
 }

--- a/config/validation.go
+++ b/config/validation.go
@@ -3,7 +3,9 @@ package config
 import (
 	"bytes"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -70,6 +72,16 @@ func ValidateYAML(data []byte) ValidationResult {
 			Errors: []ValidationIssue{{Path: "$", Message: err.Error()}},
 		}
 	}
+	var extra any
+	if err := decoder.Decode(&extra); err != nil && !errors.Is(err, io.EOF) {
+		return ValidationResult{
+			Errors: []ValidationIssue{{Path: "$", Message: err.Error()}},
+		}
+	} else if err == nil {
+		return ValidationResult{
+			Errors: []ValidationIssue{{Path: "$", Message: "only one YAML document is allowed"}},
+		}
+	}
 	cfg := &Config{
 		Orgs:        raw.Orgs,
 		Repos:       raw.Repos,
@@ -115,8 +127,8 @@ func ValidateConfig(cfg *Config) ValidationResult {
 	if len(cfg.Orgs) == 0 && len(cfg.Repos) == 0 {
 		addError("$", "at least one org or repo is required")
 	}
-	if cfg.IdleTimeout <= 0 {
-		addError("idle_timeout", "must be greater than 0")
+	if cfg.IdleTimeout <= 0 || cfg.IdleTimeout > 24*time.Hour {
+		addError("idle_timeout", "must be greater than 0 and no more than 24h")
 	}
 	if _, err := cfg.ParsedLogLevel(); err != nil {
 		addError("log_level", "must be debug, info, warn, or error")
@@ -138,6 +150,7 @@ func ValidateConfig(cfg *Config) ValidationResult {
 	if cfg.CORS.MaxAge < 0 || cfg.CORS.MaxAge > 86400 {
 		addError("cors.max_age", "must be between 0 and 86400")
 	}
+	validateCORS(cfg.CORS, addError)
 	validateWritablePath(cfg.DBPath, "db_path", addError)
 	validateWritablePath(cfg.LogPath, "log_path", addError)
 
@@ -145,7 +158,7 @@ func ValidateConfig(cfg *Config) ValidationResult {
 	for index := range cfg.Orgs {
 		org := &cfg.Orgs[index]
 		path := "orgs[" + strconv.Itoa(index) + "]"
-		if !validGitHubName(org.Org) {
+		if !validGitHubOwner(org.Org) {
 			addError(path+".org", "must be a valid GitHub organization name")
 		}
 		validateAuthAll(&org.Auth, path+".auth", addError)
@@ -163,7 +176,7 @@ func ValidateConfig(cfg *Config) ValidationResult {
 		repo := &cfg.Repos[index]
 		path := "repos[" + strconv.Itoa(index) + "]"
 		parts := strings.Split(repo.Repo, "/")
-		if len(parts) != 2 || !validGitHubName(parts[0]) || !validGitHubName(parts[1]) {
+		if len(parts) != 2 || !validGitHubOwner(parts[0]) || !validGitHubRepository(parts[1]) {
 			addError(path+".repo", "must use owner/repo format")
 		}
 		validateAuthAll(&repo.Auth, path+".auth", addError)
@@ -181,10 +194,34 @@ func ValidateConfig(cfg *Config) ValidationResult {
 	return result
 }
 
-var githubNamePattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?$`)
+var (
+	githubOwnerPattern      = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
+	githubRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,100}$`)
+)
 
-func validGitHubName(value string) bool {
-	return githubNamePattern.MatchString(value)
+func validGitHubOwner(value string) bool {
+	return githubOwnerPattern.MatchString(value) && !strings.Contains(value, "--")
+}
+
+func validGitHubRepository(value string) bool {
+	return githubRepositoryPattern.MatchString(value)
+}
+
+func validateCORS(cors CORSConfig, addError func(string, string)) {
+	if cors.AllowMethods != "" {
+		methods := strings.Split(cors.AllowMethods, ",")
+		for _, method := range methods {
+			switch strings.TrimSpace(method) {
+			case "GET", "POST", "OPTIONS":
+			default:
+				addError("cors.allow_methods", "may contain only GET, POST, and OPTIONS")
+				return
+			}
+		}
+	}
+	if strings.Contains(cors.AllowHeaders, "\n") || strings.Contains(cors.ExposeHeaders, "\n") {
+		addError("cors", "header lists must stay on one line")
+	}
 }
 
 func validateAuthAll(auth *AuthConfig, path string, addError func(string, string)) {
@@ -252,6 +289,18 @@ func validateWritablePath(path, yamlPath string, addError func(string, string)) 
 		return
 	}
 	dir := filepath.Dir(path)
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			addError(yamlPath, "must be a file path")
+			return
+		}
+		file, openErr := os.OpenFile(path, os.O_WRONLY, 0)
+		if openErr != nil {
+			addError(yamlPath, "file is not writable: "+openErr.Error())
+			return
+		}
+		_ = file.Close()
+	}
 	if info, err := os.Stat(dir); err == nil {
 		if !info.IsDir() {
 			addError(yamlPath, "parent path is not a directory")

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -16,6 +16,7 @@ import { useDashboardSync } from './hooks/useDashboardSync'
 import { useDashboardStore } from './store/useDashboardStore'
 import type {
   ConfigStatus,
+  JobLog,
   JobRecord,
   MachineVitals,
   RunnerSet,
@@ -247,31 +248,78 @@ function JobsPage({ jobs: initialJobs, now }: { jobs: JobRecord[]; now: Date }) 
   const [status, setStatus] = useState('')
   const [repository, setRepository] = useState('')
   const [workflow, setWorkflow] = useState('')
+  const [runnerSet, setRunnerSet] = useState('')
+  const [range, setRange] = useState('24')
+  const [cursor, setCursor] = useState('')
+  const [previousCursors, setPreviousCursors] = useState<string[]>([])
   const [selected, setSelected] = useState<JobRecord | null>(null)
   const jobs = useSWR(
-    ['jobs', status, repository, workflow],
-    () => fetchJobs({ status, repository, workflow, pageSize: 100 }),
+    ['jobs', status, repository, workflow, runnerSet, range, cursor],
+    () => {
+      const to = new Date()
+      const from = new Date(to.getTime() - Number(range) * 60 * 60 * 1000)
+      return fetchJobs({
+        status,
+        repository,
+        workflow,
+        runnerSet,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        cursor,
+        pageSize: 50,
+      })
+    },
     { refreshInterval: 5000, fallbackData: { jobs: initialJobs, nextCursor: '' } },
   )
+
+  function resetPage() {
+    setCursor('')
+    setPreviousCursors([])
+  }
+
+  function nextPage() {
+    if (!jobs.data?.nextCursor) return
+    setPreviousCursors(values => [...values, cursor])
+    setCursor(jobs.data.nextCursor)
+  }
+
+  function previousPage() {
+    setPreviousCursors(values => {
+      const next = [...values]
+      setCursor(next.pop() ?? '')
+      return next
+    })
+  }
   return (
     <>
       <PageHeader title="Jobs" detail="Recent job history from local storage." />
       <section className="filter-bar">
-        <select aria-label="Job status" value={status} onChange={event => setStatus(event.target.value)}>
+        <select aria-label="Job status" value={status} onChange={event => { setStatus(event.target.value); resetPage() }}>
           <option value="">All results</option>
           <option value="running">Running</option>
           <option value="succeeded">Success</option>
           <option value="failed">Failure</option>
           <option value="canceled">Canceled</option>
         </select>
-        <input aria-label="Repository filter" placeholder="Repository" value={repository} onChange={event => setRepository(event.target.value)} />
-        <input aria-label="Workflow filter" placeholder="Workflow" value={workflow} onChange={event => setWorkflow(event.target.value)} />
+        <input aria-label="Runner set filter" placeholder="Runner set" value={runnerSet} onChange={event => { setRunnerSet(event.target.value); resetPage() }} />
+        <input aria-label="Repository filter" placeholder="Repository" value={repository} onChange={event => { setRepository(event.target.value); resetPage() }} />
+        <input aria-label="Workflow filter" placeholder="Workflow" value={workflow} onChange={event => { setWorkflow(event.target.value); resetPage() }} />
+        <select aria-label="Job time range" value={range} onChange={event => { setRange(event.target.value); resetPage() }}>
+          <option value="1">Last hour</option>
+          <option value="24">Last 24 hours</option>
+          <option value="168">Last 7 days</option>
+          <option value="720">Last 30 days</option>
+        </select>
       </section>
       <section className="panel">
         <PanelHeader title="Job records" detail={`${jobs.data?.jobs.length ?? 0} records`} />
         {jobs.error
           ? <EmptyState title="Job history unavailable" detail={String(jobs.error)} />
           : <JobTable jobs={jobs.data?.jobs ?? []} now={now} onSelect={setSelected} />}
+        <div className="pager">
+          <button className="text-button" disabled={previousCursors.length === 0} onClick={previousPage}>Previous</button>
+          <button className="text-button" disabled={!jobs.data?.nextCursor} onClick={nextPage}>Next</button>
+        </div>
       </section>
       {selected && <JobDetail job={selected} onClose={() => setSelected(null)} />}
     </>
@@ -313,14 +361,45 @@ function JobTable({ jobs, now, onSelect }: { jobs: JobRecord[]; now: Date; onSel
 }
 
 function JobDetail({ job, onClose }: { job: JobRecord; onClose: () => void }) {
-  const logs = useSWR(['jobLogs', job.id], () => fetchJobLogs(job.id), {
-    refreshInterval: job.result === 'running' ? 2000 : 0,
-  })
+  const [logLines, setLogLines] = useState<JobLog[]>([])
   const resources = useSWR(['jobResources', job.id], () => fetchJobResources(job.id), {
     refreshInterval: job.result === 'running' ? 5000 : 0,
   })
   const samples = resources.data ?? []
   const estimate = samples.some(sample => sample.accuracy === 'estimate')
+
+  useEffect(() => {
+    let stopped = false
+    let sequence = 0
+    let lines: JobLog[] = []
+    let timer = 0
+
+    async function load() {
+      try {
+        const result = await fetchJobLogs(job.id, sequence)
+        if (stopped) return
+        if (result.lines.length > 0) {
+          lines = [...lines, ...result.lines]
+          sequence = result.nextSequence
+          setLogLines(lines)
+        }
+        const delay = result.lines.length === 500 ? 0 : 2000
+        if (job.result === 'running' || result.lines.length === 500) {
+          timer = window.setTimeout(load, delay)
+        }
+      } catch {
+        if (!stopped && job.result === 'running') {
+          timer = window.setTimeout(load, 2000)
+        }
+      }
+    }
+
+    void load()
+    return () => {
+      stopped = true
+      window.clearTimeout(timer)
+    }
+  }, [job.id, job.result])
   return (
     <div className="detail-overlay" role="dialog" aria-modal="true" aria-label="Job detail">
       <section className="detail-panel">
@@ -337,6 +416,7 @@ function JobDetail({ job, onClose }: { job: JobRecord; onClose: () => void }) {
           ['Runner', job.runnerName],
           ['Backend', job.backend || 'Unknown'],
           ['Queued', job.queuedAt ? formatDate(job.queuedAt) : 'Unavailable'],
+          ['Scale set assigned', job.scaleSetAssignedAt ? formatDate(job.scaleSetAssignedAt) : 'Unavailable'],
           ['Runner assigned', job.runnerAssignedAt ? formatDate(job.runnerAssignedAt) : 'Unavailable'],
           ['Started', formatDate(job.startedAt)],
           ['Completed', job.completedAt ? formatDate(job.completedAt) : 'Running'],
@@ -344,10 +424,21 @@ function JobDetail({ job, onClose }: { job: JobRecord; onClose: () => void }) {
         {job.actionsURL && <a className="external-link" href={job.actionsURL} target="_blank" rel="noreferrer">Open in GitHub Actions</a>}
         <div className="panel-header"><h2>Resource history</h2><span>{estimate ? 'Tart host estimate' : 'Backend data'}</span></div>
         {estimate && <div className="notice warning">Guest resource usage is unavailable. Tart values show VM allocation and host side estimates.</div>}
-        <ResourceChart samples={samples} field="cpuPercent" label="CPU" suffix="%" />
-        <ResourceChart samples={samples} field="memoryUsedBytes" label="Memory" format={formatBytes} />
-        <div className="panel-header"><h2>Runner log</h2><span>{logs.data?.lines.length ?? 0} chunks</span></div>
-        <pre className="job-log">{logs.data?.lines.map(line => line.text).join('') || 'No log data is available.'}</pre>
+        {estimate
+          ? <>
+            <ResourceChart samples={samples} field="memoryAvailableBytes" label="Memory allocation" format={formatBytes} />
+            <ResourceChart samples={samples} field="diskAvailableBytes" label="Disk allocation" format={formatBytes} />
+          </>
+          : <>
+            <ResourceChart samples={samples} field="cpuPercent" label="CPU" suffix="%" />
+            <ResourceChart samples={samples} field="memoryUsedBytes" label="Memory" format={formatBytes} />
+            <ResourceChart samples={samples} field="diskReadBytes" label="Disk read" format={formatBytes} />
+            <ResourceChart samples={samples} field="diskWriteBytes" label="Disk written" format={formatBytes} />
+            <ResourceChart samples={samples} field="networkReceiveBytes" label="Network received" format={formatBytes} />
+            <ResourceChart samples={samples} field="networkSendBytes" label="Network sent" format={formatBytes} />
+          </>}
+        <div className="panel-header"><h2>Runner log</h2><span>{logLines.length} chunks</span></div>
+        <pre className="job-log">{logLines.map(line => line.text).join('') || 'No log data is available.'}</pre>
       </section>
     </div>
   )
@@ -539,9 +630,10 @@ function SystemPage() {
   const store = useDashboardStore()
   const system = store.systemInfo
   const daemon = store.daemonStatus
+  const [historyHours, setHistoryHours] = useState(1)
   const history = useSWR(
-    'hostResources',
-    () => fetchHostResources(new Date(Date.now() - 60 * 60 * 1000), new Date()),
+    ['hostResources', historyHours],
+    () => fetchHostResources(new Date(Date.now() - historyHours * 60 * 60 * 1000), new Date()),
     { refreshInterval: 5000 },
   )
   return (
@@ -566,6 +658,8 @@ function SystemPage() {
             rows={[
               ['Database', system?.databasePath || 'Unknown'],
               ['Database size', formatBytes(system?.databaseSizeBytes ?? 0)],
+              ['Log file', system?.logPath || 'Standard output'],
+              ['Log size', formatBytes(system?.logSizeBytes ?? 0)],
               ['Config', store.configStatus?.path || 'No config file'],
             ]}
           />
@@ -573,9 +667,20 @@ function SystemPage() {
       </div>
       <section className="panel">
         <PanelHeader title="Host resources" detail={history.data?.earliestAt ? `Available since ${formatDate(history.data.earliestAt)}` : 'Current sample'} />
+        <select className="range-select" aria-label="Host history range" value={historyHours} onChange={event => setHistoryHours(Number(event.target.value))}>
+          <option value={1}>Last hour</option>
+          <option value={24}>Last 24 hours</option>
+          <option value={168}>Last 7 days</option>
+          <option value={720}>Last 30 days</option>
+        </select>
         <Vitals vitals={store.machineVitals} />
         <ResourceChart samples={history.data?.samples ?? []} field="cpuPercent" label="CPU history" suffix="%" />
         <ResourceChart samples={history.data?.samples ?? []} field="memoryUsedBytes" label="Memory history" format={formatBytes} />
+        <ResourceChart samples={history.data?.samples ?? []} field="diskReadBytes" label="Disk read history" format={formatBytes} />
+        <ResourceChart samples={history.data?.samples ?? []} field="diskWriteBytes" label="Disk write history" format={formatBytes} />
+        {(history.data?.samples ?? []).some(sample => sample.temperatureCelsius !== 0)
+          ? <ResourceChart samples={history.data?.samples ?? []} field="temperatureCelsius" label="Temperature history" suffix="°C" />
+          : <EmptyState title="Temperature is unavailable on this system" />}
       </section>
     </>
   )
@@ -589,7 +694,7 @@ function ResourceChart({
   format,
 }: {
   samples: ResourceSample[]
-  field: 'cpuPercent' | 'memoryUsedBytes'
+  field: 'cpuPercent' | 'memoryUsedBytes' | 'memoryAvailableBytes' | 'diskAvailableBytes' | 'diskReadBytes' | 'diskWriteBytes' | 'networkReceiveBytes' | 'networkSendBytes' | 'temperatureCelsius'
   label: string
   suffix?: string
   format?: (value: number) => string

--- a/dashboard/src/api/fetchers.ts
+++ b/dashboard/src/api/fetchers.ts
@@ -219,6 +219,8 @@ export async function fetchJobs(filters: {
   runnerSet?: string
   repository?: string
   workflow?: string
+  from?: string
+  to?: string
   cursor?: string
   pageSize?: number
 }): Promise<{ jobs: JobRecord[]; nextCursor: string }> {
@@ -422,5 +424,7 @@ export async function fetchSystemInfo(): Promise<SystemInfo> {
     goVersion: data.goVersion ?? '',
     databasePath: data.databasePath ?? '',
     databaseSizeBytes: data.databaseSizeBytes ?? 0,
+    logPath: data.logPath ?? '',
+    logSizeBytes: data.logSizeBytes ?? 0,
   }
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -513,9 +513,25 @@ input:focus {
 
 .filter-bar {
   display: grid;
-  grid-template-columns: 180px minmax(180px, 1fr) minmax(180px, 1fr);
+  grid-template-columns: repeat(5, minmax(140px, 1fr));
   gap: 10px;
   margin-bottom: 14px;
+}
+
+.pager {
+  padding-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.range-select {
+  margin-bottom: 14px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text);
+  background: var(--panel-raised);
 }
 
 .filter-bar input,

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -151,4 +151,6 @@ export interface SystemInfo {
   goVersion: string
   databasePath: string
   databaseSizeBytes: number
+  logPath: string
+  logSizeBytes: number
 }

--- a/gen/controlplane/v1/controlplane.pb.go
+++ b/gen/controlplane/v1/controlplane.pb.go
@@ -3057,6 +3057,8 @@ type GetSystemInfoResponse struct {
 	GoVersion         string                 `protobuf:"bytes,3,opt,name=go_version,json=goVersion,proto3" json:"go_version,omitempty"`
 	DatabasePath      string                 `protobuf:"bytes,4,opt,name=database_path,json=databasePath,proto3" json:"database_path,omitempty"`
 	DatabaseSizeBytes int64                  `protobuf:"varint,5,opt,name=database_size_bytes,json=databaseSizeBytes,proto3" json:"database_size_bytes,omitempty"`
+	LogPath           string                 `protobuf:"bytes,6,opt,name=log_path,json=logPath,proto3" json:"log_path,omitempty"`
+	LogSizeBytes      int64                  `protobuf:"varint,7,opt,name=log_size_bytes,json=logSizeBytes,proto3" json:"log_size_bytes,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -3122,6 +3124,20 @@ func (x *GetSystemInfoResponse) GetDatabasePath() string {
 func (x *GetSystemInfoResponse) GetDatabaseSizeBytes() int64 {
 	if x != nil {
 		return x.DatabaseSizeBytes
+	}
+	return 0
+}
+
+func (x *GetSystemInfoResponse) GetLogPath() string {
+	if x != nil {
+		return x.LogPath
+	}
+	return ""
+}
+
+func (x *GetSystemInfoResponse) GetLogSizeBytes() int64 {
+	if x != nil {
+		return x.LogSizeBytes
 	}
 	return 0
 }
@@ -3353,14 +3369,16 @@ const file_controlplane_v1_controlplane_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"a\n" +
 	"\x1dRestoreConfigRevisionResponse\x12@\n" +
 	"\x06status\x18\x01 \x01(\v2(.controlplane.v1.GetConfigStatusResponseR\x06status\"\x16\n" +
-	"\x14GetSystemInfoRequest\"\xaf\x01\n" +
+	"\x14GetSystemInfoRequest\"\xf0\x01\n" +
 	"\x15GetSystemInfoResponse\x12\x0e\n" +
 	"\x02os\x18\x01 \x01(\tR\x02os\x12\x12\n" +
 	"\x04arch\x18\x02 \x01(\tR\x04arch\x12\x1d\n" +
 	"\n" +
 	"go_version\x18\x03 \x01(\tR\tgoVersion\x12#\n" +
 	"\rdatabase_path\x18\x04 \x01(\tR\fdatabasePath\x12.\n" +
-	"\x13database_size_bytes\x18\x05 \x01(\x03R\x11databaseSizeBytes*H\n" +
+	"\x13database_size_bytes\x18\x05 \x01(\x03R\x11databaseSizeBytes\x12\x19\n" +
+	"\blog_path\x18\x06 \x01(\tR\alogPath\x12$\n" +
+	"\x0elog_size_bytes\x18\a \x01(\x03R\flogSizeBytes*H\n" +
 	"\aBackend\x12\x17\n" +
 	"\x13BACKEND_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fBACKEND_TART\x10\x01\x12\x12\n" +

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -35,6 +35,7 @@ type Server struct {
 	authService       *auth.Service
 	configState       *configstate.Service
 	databasePath      string
+	logPath           string
 	idleTimeout       time.Duration
 	cors              config.CORSConfig
 }
@@ -44,6 +45,7 @@ type Dependencies struct {
 	Auth         *auth.Service
 	ConfigState  *configstate.Service
 	DatabasePath string
+	LogPath      string
 }
 
 // NewServer creates an API server backed by the management and vitals services.
@@ -70,6 +72,7 @@ func NewServer(managementService *management.Service, vitalsService *vitals.Serv
 		server.authService = dependencies[0].Auth
 		server.configState = dependencies[0].ConfigState
 		server.databasePath = dependencies[0].DatabasePath
+		server.logPath = dependencies[0].LogPath
 	}
 	return server
 }
@@ -580,6 +583,12 @@ func (s *Server) GetSystemInfo(_ context.Context, _ *connect.Request[controlplan
 	if s.databasePath != "" {
 		if info, err := os.Stat(s.databasePath); err == nil {
 			response.DatabaseSizeBytes = info.Size()
+		}
+	}
+	response.LogPath = s.logPath
+	if s.logPath != "" {
+		if info, err := os.Stat(s.logPath); err == nil {
+			response.LogSizeBytes = info.Size()
 		}
 	}
 	return connect.NewResponse(response), nil

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -75,6 +75,12 @@ func Open(dbPath string) (*Service, error) {
 		db.Close()
 		return nil, fmt.Errorf("migrate auth database %s: %w", dbPath, err)
 	}
+	if dbPath != ":memory:" {
+		if err := os.Chmod(dbPath, 0o600); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("set auth database permissions %s: %w", dbPath, err)
+		}
+	}
 
 	service := &Service{db: db}
 	setupRequired, err := service.SetupRequired(context.Background())

--- a/internal/management/host.go
+++ b/internal/management/host.go
@@ -85,27 +85,65 @@ func (svc *Service) cleanHistory(now time.Time) {
 			OR recorded_at < ?`,
 		now.Add(-rawHostRetention), now.Add(-historyRetention),
 	)
-	_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_logs WHERE recorded_at < ?`, now.Add(-historyRetention))
-	_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_resource_samples WHERE recorded_at < ?`, now.Add(-historyRetention))
+	_, _ = svc.db.ExecContext(ctx, `
+		DELETE FROM job_logs
+		WHERE recorded_at < ? OR job_id IN (
+			SELECT id FROM jobs
+			WHERE result != 'running' AND COALESCE(completed_at, started_at) < ?
+		)`,
+		now.Add(-historyRetention), now.Add(-historyRetention),
+	)
+	_, _ = svc.db.ExecContext(ctx, `
+		DELETE FROM job_resource_samples
+		WHERE recorded_at < ? OR job_id IN (
+			SELECT id FROM jobs
+			WHERE result != 'running' AND COALESCE(completed_at, started_at) < ?
+		)`,
+		now.Add(-historyRetention), now.Add(-historyRetention),
+	)
+	_, _ = svc.db.ExecContext(ctx, `
+		DELETE FROM jobs
+		WHERE result != 'running' AND COALESCE(completed_at, started_at) < ?`,
+		now.Add(-historyRetention),
+	)
 
-	if databaseSize(svc.databasePath) <= maxHistoryBytes {
+	currentSize := databaseSize(svc.databasePath)
+	if currentSize <= maxHistoryBytes {
 		return
 	}
-	for databaseSize(svc.databasePath) > targetHistoryBytes {
-		var jobID string
-		err := svc.db.QueryRowContext(ctx, `
-			SELECT id FROM jobs
-			WHERE result != 'running'
-			ORDER BY COALESCE(completed_at, started_at)
-			LIMIT 1`).Scan(&jobID)
-		if err != nil {
+	for currentSize > targetHistoryBytes {
+		bytesToFree := currentSize - targetHistoryBytes
+		var freed int64
+		for freed < bytesToFree {
+			var jobID string
+			var estimatedBytes int64
+			err := svc.db.QueryRowContext(ctx, `
+				SELECT jobs.id,
+					4096
+					+ COALESCE((SELECT SUM(LENGTH(text)) FROM job_logs WHERE job_id = jobs.id), 0)
+					+ COALESCE((SELECT COUNT(*) * 256 FROM job_resource_samples WHERE job_id = jobs.id), 0)
+				FROM jobs
+				WHERE result != 'running'
+				ORDER BY COALESCE(completed_at, started_at)
+				LIMIT 1`).Scan(&jobID, &estimatedBytes)
+			if err != nil {
+				break
+			}
+			_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_logs WHERE job_id = ?`, jobID)
+			_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_resource_samples WHERE job_id = ?`, jobID)
+			_, _ = svc.db.ExecContext(ctx, `DELETE FROM jobs WHERE id = ? AND result != 'running'`, jobID)
+			freed += estimatedBytes
+		}
+		if freed == 0 {
 			break
 		}
-		_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_logs WHERE job_id = ?`, jobID)
-		_, _ = svc.db.ExecContext(ctx, `DELETE FROM job_resource_samples WHERE job_id = ?`, jobID)
-		_, _ = svc.db.ExecContext(ctx, `DELETE FROM jobs WHERE id = ? AND result != 'running'`, jobID)
+		_, _ = svc.db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
+		if _, err := svc.db.ExecContext(ctx, `VACUUM`); err != nil {
+			slog.Warn("failed to compact history database", "err", err)
+			break
+		}
+		currentSize = databaseSize(svc.databasePath)
 	}
-	_, _ = svc.db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
 }
 
 func (svc *Service) HostSamples(from, to time.Time) ([]HostSample, *time.Time) {

--- a/proto/controlplane/v1/controlplane.proto
+++ b/proto/controlplane/v1/controlplane.proto
@@ -408,4 +408,6 @@ message GetSystemInfoResponse {
   string go_version = 3;
   string database_path = 4;
   int64 database_size_bytes = 5;
+  string log_path = 6;
+  int64 log_size_bytes = 7;
 }


### PR DESCRIPTION
## Problem

Final acceptance found missing job paging and history controls, incomplete resource curves, and a SQLite cleanup path that could delete more completed jobs than needed.

## Solution

Complete the UI controls and resource views, harden validation and storage cleanup, and report log storage in System.

## Major Changes

1. Jobs and history
   Add runner set and time filters, cursor paging, accumulating log cursor polling, and full backend and host resource curves.
2. Retention
   Estimate bytes to free, preserve running jobs, compact in batches, and measure storage again until it is below the target.
3. Config and security
   Reject multiple YAML documents, tighten duration, CORS, GitHub, and path checks, and set the auth database and configured log files to mode 0600.
4. System
   Write optional configured logs and show the log path and size.

## Validation

1. `make check`
2. Dashboard build and lint
3. Existing Go tests
4. Real browser checks for all five pages, job filters, paging, host history controls, errors, and 390px layout
5. Real five second host samples and one minute rollup query
6. Config recovery mode using an invalid disk config and the last active revision

Tracked by #84