### PR TITLE
docs(console): document setup and account recovery

### DIFF
--- a/doc-site/src/content/docs/how-to/reset-console-password.md
+++ b/doc-site/src/content/docs/how-to/reset-console-password.md
@@ -1,0 +1,72 @@
+---
+title: How to reset the Console password
+description: Clear the local Console admin and create a new password.
+---
+
+Reset removes the current admin password and every Console session. It does not remove runner config, jobs, logs, or resource history.
+
+## Homebrew
+
+Stop the daemon:
+
+```sh
+brew services stop elastic-fruit-runner
+```
+
+Reset the admin:
+
+```sh
+elastic-fruit-runner reset-password --config ~/.elastic-fruit-runner/config.yaml
+```
+
+Start the daemon:
+
+```sh
+brew services start elastic-fruit-runner
+```
+
+## Docker Compose
+
+Stop the daemon:
+
+```sh
+docker compose stop elastic-fruit-runner
+```
+
+Run the reset command with the same config and data volumes:
+
+```sh
+docker compose run --rm elastic-fruit-runner reset-password --config /etc/elastic-fruit-runner/config.yaml
+```
+
+Start the daemon:
+
+```sh
+docker compose up -d elastic-fruit-runner
+```
+
+## systemd
+
+Stop the daemon:
+
+```sh
+sudo systemctl stop elastic-fruit-runner
+```
+
+Run the reset command with the service config:
+
+```sh
+sudo elastic-fruit-runner reset-password --config /etc/elastic-fruit-runner/config.yaml
+```
+
+Start the daemon:
+
+```sh
+sudo systemctl start elastic-fruit-runner
+```
+
+## Create the new password
+
+Read the new setup code from the local daemon log. Then follow [How to set up the Console](/how-to/set-up-console/).
+
+Old browser sessions no longer work after the reset.

--- a/doc-site/src/content/docs/how-to/set-up-console.md
+++ b/doc-site/src/content/docs/how-to/set-up-console.md
@@ -1,0 +1,76 @@
+---
+title: How to set up the Console
+description: Use the first start setup code to create the Console admin password.
+---
+
+## Start Elastic Fruit Runner
+
+Start the service with the method used for your installation.
+
+For Homebrew:
+
+```sh
+brew services start elastic-fruit-runner
+```
+
+For Docker Compose:
+
+```sh
+docker compose up -d elastic-fruit-runner
+```
+
+For systemd:
+
+```sh
+sudo systemctl start elastic-fruit-runner
+```
+
+## Find the setup code
+
+The daemon creates a setup code only when no admin password exists. The code is valid only for the current daemon process.
+
+For Homebrew:
+
+```sh
+grep '"msg":"console admin setup required"' /opt/homebrew/var/log/elastic-fruit-runner.log | tail -n 1
+```
+
+For Docker Compose:
+
+```sh
+docker compose logs elastic-fruit-runner | grep '"msg":"console admin setup required"' | tail -n 1
+```
+
+For systemd:
+
+```sh
+sudo journalctl -u elastic-fruit-runner | grep '"msg":"console admin setup required"' | tail -n 1
+```
+
+Treat the setup code as a password. Do not paste it into an issue, chat, screenshot, or shared log.
+
+## Create the admin
+
+1. Open [http://127.0.0.1:8080](http://127.0.0.1:8080).
+2. Enter the setup code.
+3. Enter an admin password with 12 to 256 characters.
+4. Enter the password again.
+5. Select **Create admin**.
+
+The Console signs you in and opens **Overview**.
+
+## Confirm access
+
+Open each page in the left navigation:
+
+1. Overview
+2. Jobs
+3. Runner Sets
+4. Config
+5. System
+
+Sign out, then sign in again with the admin password.
+
+Only one local admin account exists. A session lasts up to 24 hours.
+
+If the setup code is missing or no longer valid, [reset the Console password](/how-to/reset-console-password/).

--- a/doc-site/src/content/docs/how-to/use-console.md
+++ b/doc-site/src/content/docs/how-to/use-console.md
@@ -1,100 +1,36 @@
 ---
-title: Use the operations console
-description: Set up, operate, and recover the Elastic Fruit Runner console.
+title: Use the operations Console
+description: Find the guide you need to set up, operate, and recover the Elastic Fruit Runner Console.
 ---
 
-The console is served by the daemon on `http://127.0.0.1:8080` by default. It manages one daemon and one host.
+The Console is included in the Elastic Fruit Runner binary. It manages one daemon and one host.
 
-## First login
+Open [http://127.0.0.1:8080](http://127.0.0.1:8080) when you use the default listen address.
 
-On the first start, the daemon writes a one time setup code to its local log. Open the console, enter that code, and set the admin password.
+## Start here
 
-The password is stored as a strong hash. Login uses an HttpOnly session cookie. The console never returns PAT values or private key contents.
+* [Set up the Console](/how-to/set-up-console/)
+* [Reset the Console password](/how-to/reset-console-password/)
+* [Upgrade Elastic Fruit Runner](/how-to/upgrade/)
 
-## Password recovery
+## Console pages
 
-Stop the daemon, clear the local admin password, and start the daemon again:
+* **Overview** shows current daemon, runner, job, config, and host state.
+* **Jobs** shows job history, filters, logs, resource data, and GitHub Actions links.
+* **Runner Sets** shows scope, backend, image, labels, capacity, connection state, and active runners.
+* **Config** shows active and disk config, validation, revisions, and restart instructions.
+* **System** shows runtime details, storage use, current host state, and host history.
 
-```sh
-elastic-fruit-runner reset-password --config /path/to/config.yaml
-```
+## Related reference
 
-The next start writes a new setup code to the local log. Existing console sessions are removed.
+* [Configuration reference](/reference/configuration/)
+* [CLI reference](/reference/cli/)
+* [Troubleshooting](/how-to/troubleshooting/)
 
-## Pages
+## Network boundary
 
-| Page | Purpose |
-|------|---------|
-| Overview | Current daemon, GitHub, runner, job, config, and host state |
-| Jobs | Job filters, GitHub Actions links, lifecycle times, logs, and resource history |
-| Runner Sets | Scope, backend, image, labels, capacity, connection state, and active runners |
-| Config | Active config, disk config, validation, editing, revisions, and restart commands |
-| System | Runtime details, storage use, current host state, and host history |
+The daemon does not provide TLS. Keep the default local address when possible.
 
-Docker job data comes from container logs and Docker resource data.
+If another device must reach the Console, use a trusted private network or place the daemon behind a TLS reverse proxy that you operate. Do not expose the Console directly to the public internet.
 
-Tart job logs come from the runner process in the VM. Guest resource use is not available without a guest agent, so the console labels Tart allocation and host side values as estimates.
-
-## Edit config
-
-The active config is the version loaded when the daemon started. The disk config is the current file content.
-
-Saving follows this order:
-
-1. Parse YAML.
-2. Check unknown fields, duplicate keys, required values, ranges, names, auth choice, backend settings, paths, CORS, and private key PEM data.
-3. Stop when any error exists.
-4. Ask for confirmation when only warnings exist.
-5. Replace the disk file in one atomic operation.
-6. Set file permissions to `0600`.
-7. Save a revision.
-8. Show `Restart required`.
-
-Saving does not reload controllers and does not restart the daemon.
-
-Run the command that matches the installation:
-
-```sh
-brew services restart elastic-fruit-runner
-docker compose restart elastic-fruit-runner
-sudo systemctl restart elastic-fruit-runner
-```
-
-A restart can interrupt running jobs. Check the Jobs page before restarting.
-
-## Config recovery
-
-The daemon keeps the newest ten config revisions.
-
-If the disk config is invalid and an active revision exists, the daemon starts with the last active revision. The Config page reports `Disk config invalid`.
-
-If no active revision exists, the daemon starts in config mode on the default local address. Controllers do not start. Authentication and the Config page remain available.
-
-Restoring a revision only writes it to disk. A manual restart is still required.
-
-## Data history
-
-Host data is collected every five seconds. Raw samples remain available for twenty four hours. One minute summaries remain available for thirty days.
-
-Job records, job logs, job resource data, and host resource data share a ten GB limit. Cleanup removes data older than thirty days first. If storage is still above the limit, cleanup removes the oldest completed jobs until use is below nine GB. Running jobs are never removed.
-
-The System page shows the earliest available host sample.
-
-## Upgrade
-
-Before an upgrade, confirm that the current disk config is valid and note the active hash.
-
-After an upgrade:
-
-1. Open Overview and confirm GitHub connection state.
-2. Open Config and confirm the active and disk hashes.
-3. Open Jobs and confirm new work appears.
-4. Open System and confirm new host samples appear.
-
-An existing valid config becomes the first active revision after controllers initialize successfully.
-
-## Network access
-
-The daemon does not provide TLS. Keep the console on a trusted local network or place it behind a TLS reverse proxy.
-
-Every management RPC requires login. Config save, revision restore, and logout also require a valid CSRF token.
+Every management call requires the admin session. Config writes, revision restore, and sign out also require a valid CSRF token.


### PR DESCRIPTION
## Problem

The Console guide mixed setup, daily operations, config behavior, storage rules, and security details in one page.

## Solution

Turn the existing route into a stable Console hub. Add focused guides for first admin setup and password recovery.

## Major Changes

* Console hub
  * Keep the existing URL and point users to task specific guides
* First setup
  * Cover setup code discovery, password rules, and access checks
* Password recovery
  * Cover Homebrew, Docker Compose, and systemd reset flows

Closes #96
Tracked by #94

## Validation

* `pnpm --dir doc-site build`
* `prek run --all-files` with the matching Homebrew Go toolchain