### PR TITLE
docs(console): document job, runner, and host operations

### DIFF
--- a/doc-site/src/content/docs/how-to/check-runner-capacity.md
+++ b/doc-site/src/content/docs/how-to/check-runner-capacity.md
@@ -1,0 +1,51 @@
+---
+title: How to check runner capacity
+description: Use the Runner Sets page to check GitHub connection, configured capacity, and active runner state.
+---
+
+Open **Runner Sets** in the Console.
+
+## Check the configured set
+
+Each card shows:
+
+* Runner set name
+* Docker or Tart backend
+* Active runner count and maximum runner count
+* GitHub organization or repository scope
+* Image
+* Labels
+* GitHub connection
+
+If the page says **No runner sets configured**, open **Config** and confirm that at least one organization or repository contains a runner set.
+
+## Check GitHub connection
+
+The card reports **Connected** after the runner set starts listening for work.
+
+If it reports **Disconnected**:
+
+1. Check the daemon log for an auth or Scale Set error.
+2. Confirm the PAT or GitHub App settings.
+3. Confirm the organization or repository name.
+4. Confirm GitHub App installation permissions when App auth is used.
+
+See [How to configure GitHub App authentication](/how-to/configure-github-app/) for the required settings.
+
+## Check active runners
+
+The card counts runners in three states:
+
+* `preparing` means the backend is creating and registering the runner.
+* `idle` means the runner is ready for a job.
+* `busy` means the runner is running a job.
+
+The runner table shows each runner name, current state, and the time it entered that state.
+
+If the active count equals the maximum, new jobs wait until a runner finishes. Increase `max_runners` only after checking available CPU, memory, disk, and backend limits.
+
+## Check the matching job
+
+Open **Jobs** and filter by the runner set name. This connects capacity state with the jobs using that set.
+
+If a runner stays in `preparing`, use [How to investigate a job](/how-to/investigate-jobs/) and [Troubleshooting](/how-to/troubleshooting/) to check the backend.

--- a/doc-site/src/content/docs/how-to/investigate-jobs.md
+++ b/doc-site/src/content/docs/how-to/investigate-jobs.md
@@ -1,0 +1,66 @@
+---
+title: How to investigate a job
+description: Filter job history, read runner logs, inspect resource data, and open the matching GitHub Actions job.
+---
+
+## Find the job
+
+Open **Jobs** in the Console.
+
+Use one or more filters:
+
+* Result
+* Runner set
+* Repository
+* Workflow
+* Time range
+
+The time range can be one hour, 24 hours, 7 days, or 30 days. Each page contains up to 50 jobs. Use **Previous** and **Next** to move through stored history.
+
+If the table says **No jobs recorded**, confirm that a configured runner has accepted at least one job.
+
+If the table says **Job history unavailable**, check the daemon log and confirm that the configured database path is writable.
+
+## Open job detail
+
+Select a row to open the job detail panel.
+
+Check:
+
+1. Repository and workflow
+2. Runner and backend
+3. Queued time
+4. Scale set assignment time
+5. Runner assignment time
+6. Start and completion time
+
+These times show where a job spent time before its runner started work.
+
+## Read the runner log
+
+Use **Runner log** to inspect runner process output.
+
+For a running job, the Console requests new log chunks every two seconds. A completed job stops polling after all stored chunks are read.
+
+If the panel says **No log data is available**, the backend did not collect a runner log for that job. Check the daemon log for backend startup or collection errors.
+
+## Inspect resource history
+
+For a Docker job, the charts show container data:
+
+* CPU
+* Memory
+* Disk read and write
+* Network receive and send
+
+For a Tart job without guest resource data, the panel shows **Tart host estimate**. Memory and disk values describe VM allocation. Host side values are estimates and do not describe exact guest use.
+
+If a chart has fewer than two samples, the Console reports that no history is available yet.
+
+See [History and Storage Reference](/reference/history-and-storage/) for data source, accuracy, and retention rules.
+
+## Open GitHub Actions
+
+Select **Open in GitHub Actions** to open the matching workflow run and job.
+
+Use the Console log to inspect runner startup and local resource behavior. Use GitHub Actions for step output, annotations, artifacts, and workflow controls.

--- a/doc-site/src/content/docs/how-to/monitor-host-resources.md
+++ b/doc-site/src/content/docs/how-to/monitor-host-resources.md
@@ -1,0 +1,66 @@
+---
+title: How to monitor host resources
+description: Use the System page to check runtime, storage, current host use, and resource history.
+---
+
+Open **System** in the Console.
+
+## Check runtime
+
+The Runtime panel shows:
+
+* Elastic Fruit Runner version
+* Go version
+* Operating system and architecture
+* Start time
+* Uptime
+
+Use these values when reporting a problem or confirming an upgrade.
+
+If a value is **Unknown**, check the local daemon log for build or startup errors.
+
+## Check storage
+
+The Storage panel shows:
+
+* Database path and current size
+* Log path and current size
+* Config path
+
+If the log path says **Standard output**, use the log source managed by Homebrew, Docker, or systemd.
+
+See [History and Storage Reference](/reference/history-and-storage/) for cleanup order and storage limits.
+
+## Check current resources
+
+The current sample shows:
+
+* CPU use
+* Memory use
+* Disk use
+* Temperature when the host provides it
+
+Temperature is optional. **Temperature is unavailable on this system** is a supported state.
+
+## Check history
+
+Choose one range:
+
+* Last hour
+* Last 24 hours
+* Last 7 days
+* Last 30 days
+
+The page shows CPU, memory, disk read, disk write, and temperature history when enough samples exist.
+
+**Available since** reports the earliest host sample still stored. A range can start before that time, but the chart cannot show removed data.
+
+If a chart says that no history exists yet, wait for at least two samples. The daemon records a host sample every five seconds.
+
+If the whole history request fails, check database access and the daemon log.
+
+## Compare host and job data
+
+Use **System** to see pressure on the whole host. Use job detail in **Jobs** to see data collected for one runner.
+
+Host data cannot prove that one Tart guest used a specific amount of CPU or memory. Tart job values are marked as estimates when guest data is unavailable.


### PR DESCRIPTION
## Problem

Users had no focused guides for investigating job history, checking runner capacity, or reading host resource history.

## Solution

Add three task guides based on the current Console pages and data behavior.

## Major Changes

* Job investigation
  * Cover filters, paging, detail, logs, resource accuracy, and GitHub links
* Runner capacity
  * Cover scope, connection, capacity, and active runner states
* Host resources
  * Cover runtime, storage, current values, history ranges, and empty states

Closes #97
Tracked by #94

## Validation

* `pnpm --dir doc-site build`
* `prek run --all-files` with the matching Homebrew Go toolchain