### PR TITLE
docs: complete user reference

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,14 +5,14 @@
 orgs:
   - org: your-org
     auth:
-      # Option A: GitHub App (recommended)
-      github_app:
-        client_id: Iv1.xxxxxxxxxxxxxxxx
-        installation_id: 12345678
-        private_key_path: /path/to/private-key.pem
+      # Replace this example value before use.
+      pat_token: ghp_replace_me
 
-      # Option B: Personal Access Token (uncomment and remove github_app above)
-      # pat_token: ghp_xxx
+      # GitHub App alternative. Remove pat_token before enabling this block.
+      # github_app:
+      #   client_id: Iv1.xxxxxxxxxxxxxxxx
+      #   installation_id: 12345678
+      #   private_key_path: /path/to/private-key.pem
 
     runner_group: Default
     runner_sets:
@@ -52,14 +52,18 @@ orgs:
 #         max_runners: 2
 
 idle_timeout: 15m
+log_level: info
 
-# CORS configuration for the API server. All fields default to permissive
-# values suitable for local development. In production, restrict these to
-# your dashboard's actual origin.
+# Optional service and storage paths.
+# api_addr: 127.0.0.1:8080
+# db_path: /var/lib/elastic-fruit-runner/jobs.db
+# log_path: /var/log/elastic-fruit-runner/elastic-fruit-runner.log
+
+# CORS configuration. Keep the Console on the same origin when possible.
 # cors:
 #   allow_origin: "*"
 #   allow_methods: "GET, POST, OPTIONS"
-#   allow_headers: "Content-Type, Connect-Protocol-Version"
+#   allow_headers: "Content-Type, Connect-Protocol-Version, X-CSRF-Token"
 #   expose_headers: "Connect-Protocol-Version"
 #   allow_credentials: false
 #   max_age: 0

--- a/doc-site/src/content/docs/reference/cli.md
+++ b/doc-site/src/content/docs/reference/cli.md
@@ -1,55 +1,48 @@
 ---
 title: CLI Reference
-description: Command-line flags for elastic-fruit-runner.
+description: Commands and flags supported by the Elastic Fruit Runner binary.
 ---
 
-## Usage
+## Run the daemon
 
-```
-elastic-fruit-runner [flags]
+```text
+elastic-fruit-runner [--config PATH]
 ```
 
-## Flags
+The daemon loads config, starts runner controllers, starts the Console, and waits for jobs.
 
 | Flag | Default | Description |
-|------|---------|-------------|
-| `--config PATH` | (see search paths below) | Path to the YAML configuration file |
+|---|---|---|
+| `--config PATH` | Config search paths | Select one YAML config file |
 
-### Config file search paths
+Without `--config`, see [Configuration Reference](/reference/configuration/) for the search order.
 
-When `--config` is not specified, the following paths are searched in order:
-
-1. `~/.elastic-fruit-runner/config.yaml`
-2. `/opt/homebrew/var/elastic-fruit-runner/config.yaml`
-3. `/usr/local/var/elastic-fruit-runner/config.yaml`
-4. `/etc/elastic-fruit-runner/config.yaml`
-
-## Examples
-
-Run with default config file search:
+Example:
 
 ```sh
-elastic-fruit-runner
+elastic-fruit-runner --config /etc/elastic-fruit-runner/config.yaml
 ```
 
-Run with a specific config file:
+## Reset the Console password
+
+```text
+elastic-fruit-runner reset-password [--config PATH]
+```
+
+The command opens the configured SQLite database, removes the local admin password, and removes every Console session.
+
+Stop the daemon before running this command. Start it again to create a new setup code.
+
+Example:
 
 ```sh
-elastic-fruit-runner --config /path/to/config.yaml
+elastic-fruit-runner reset-password --config /etc/elastic-fruit-runner/config.yaml
 ```
 
-Override log level via environment variable:
+See [How to reset the Console password](/how-to/reset-console-password/) for service specific steps.
 
-```sh
-LOG_LEVEL=debug elastic-fruit-runner
-```
+## Exit behavior
 
-## Reset the console password
+The daemon listens for `SIGINT` and `SIGTERM`. It stops the HTTP server and runner controllers before exit.
 
-Stop the daemon before resetting the password:
-
-```sh
-elastic-fruit-runner reset-password --config /path/to/config.yaml
-```
-
-This removes the admin password and all console sessions. Start the daemon again and use the new setup code from the local log.
+Startup errors are written as JSON logs and return a nonzero exit status.

--- a/doc-site/src/content/docs/reference/configuration.md
+++ b/doc-site/src/content/docs/reference/configuration.md
@@ -1,32 +1,28 @@
 ---
 title: Configuration Reference
-description: Complete reference for all elastic-fruit-runner configuration options.
+description: YAML fields, defaults, limits, and validation rules for Elastic Fruit Runner.
 ---
 
-All configuration is done through a YAML config file. The only CLI flag is `--config` to specify the file path.
+Elastic Fruit Runner reads one YAML config file. Unknown fields, duplicate keys, and multiple YAML documents are errors.
 
-## Config file search paths
+## Config file search
 
-If `--config` is not specified, the following paths are searched in order:
+Without `--config`, the daemon checks these paths in order:
 
 1. `~/.elastic-fruit-runner/config.yaml`
 2. `/opt/homebrew/var/elastic-fruit-runner/config.yaml`
 3. `/usr/local/var/elastic-fruit-runner/config.yaml`
 4. `/etc/elastic-fruit-runner/config.yaml`
 
-## Full example
+Use `--config PATH` to select another file.
+
+## Complete example
 
 ```yaml
 orgs:
   - org: your-org
     auth:
-      # Option A: GitHub App (recommended)
-      github_app:
-        client_id: Iv1.xxxxxxxxxxxxxxxx
-        installation_id: 12345678
-        private_key_path: /path/to/private-key.pem
-      # Option B: Personal Access Token (uncomment and remove github_app above)
-      # pat_token: ghp_xxx
+      pat_token: ghp_replace_me
     runner_group: Default
     runner_sets:
       - name: efr-macos-arm64
@@ -34,140 +30,171 @@ orgs:
         image: ghcr.io/cirruslabs/macos-tahoe-xcode:26.3
         labels: [self-hosted, macos, arm64]
         max_runners: 2
-      - name: efr-linux-arm64
+
+repos:
+  - repo: your-org/your-repo
+    auth:
+      pat_token: ghp_replace_me
+    runner_sets:
+      - name: efr-repo-linux-arm64
         backend: docker
         image: ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner-dind:latest
         labels: [self-hosted, linux, arm64]
         max_runners: 4
         platform: linux/arm64
-      - name: efr-linux-amd64
-        backend: docker
-        image: ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner-dind:latest
-        labels: [self-hosted, linux, amd64]
-        max_runners: 4
-        platform: linux/amd64
-
-repos:
-  - repo: your-org/your-repo
-    auth:
-      pat_token: ghp_xxx
-    runner_sets:
-      - name: repo-runner
-        backend: docker
-        image: ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner-dind:latest
-        labels: [self-hosted, linux, arm64]
-        max_runners: 2
 
 idle_timeout: 15m
 log_level: info
+api_addr: 127.0.0.1:8080
+db_path: ./jobs.db
+log_path: ./elastic-fruit-runner.log
+
+cors:
+  allow_origin: "https://runner-console.example.com"
+  allow_methods: "GET, POST, OPTIONS"
+  allow_headers: "Content-Type, Connect-Protocol-Version, X-CSRF-Token"
+  expose_headers: "Connect-Protocol-Version"
+  allow_credentials: true
+  max_age: 3600
 ```
 
-## Top-level fields
+At least one item must exist in `orgs` or `repos`.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `orgs` | list | — | Organization-level runner set configurations |
-| `repos` | list | — | Repository-level runner set configurations |
-| `idle_timeout` | duration | `15m` | Time after which idle runners are reaped. Must be > 0 |
-| `log_level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
-| `api_addr` | string | `:8080` | Console listen address |
-| `db_path` | string | local data directory | SQLite path for job, auth, and host data |
-| `log_path` | string | empty | Optional writable log path used for path validation |
-| `cors` | object | local defaults | Console CORS settings |
+## Top level fields
 
-At least one of `orgs` or `repos` must be configured.
+| Field | Type | Default | Rules |
+|---|---|---|---|
+| `orgs` | list | empty | Organization runner scopes |
+| `repos` | list | empty | Repository runner scopes |
+| `idle_timeout` | duration | `15m` | Greater than zero and no more than `24h` |
+| `log_level` | string | `info` | `debug`, `info`, `warn`, or `error` |
+| `api_addr` | string | `:8080` | Host and port accepted by the Go network listener |
+| `db_path` | string | `~/.elastic-fruit-runner/jobs.db` | Writable file path or `:memory:` |
+| `log_path` | string | empty | Optional writable log file. Empty sends logs to standard output |
+| `cors` | object | runtime defaults | CORS response settings |
 
-## Organization configuration (`orgs[]`)
+## Organization fields
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `org` | string | yes | — | GitHub organization name |
-| `auth` | object | yes | — | Authentication configuration |
-| `runner_group` | string | no | `Default` | Runner group name |
-| `runner_sets` | list | yes | — | At least one runner set |
+Each `orgs[]` item supports:
 
-## Repository configuration (`repos[]`)
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `repo` | string | yes | Repository in `owner/repo` format |
-| `auth` | object | yes | Authentication configuration |
+| Field | Type | Required | Rules |
+|---|---|---|---|
+| `org` | string | yes | Valid GitHub organization name |
+| `auth` | object | yes | Exactly one auth method |
+| `runner_group` | string | no | Defaults to `Default` |
 | `runner_sets` | list | yes | At least one runner set |
 
-Repository-level runners always use the default runner group.
+An organization name uses GitHub owner rules. It contains 1 to 39 letters, numbers, or single hyphen characters. It cannot start or end with a hyphen.
 
-## Authentication (`auth`)
+## Repository fields
 
-Exactly one of `pat_token` or `github_app` must be configured per org/repo. They are mutually exclusive.
+Each `repos[]` item supports:
 
-### GitHub App
+| Field | Type | Required | Rules |
+|---|---|---|---|
+| `repo` | string | yes | `owner/repository` |
+| `auth` | object | yes | Exactly one auth method |
+| `runner_sets` | list | yes | At least one runner set |
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `github_app.client_id` | string | yes | GitHub App Client ID (starts with `Iv1.`) |
-| `github_app.installation_id` | integer | yes | Installation ID |
-| `github_app.private_key_path` | string | yes | Path to the private key `.pem` file |
+The repository part contains 1 to 100 letters, numbers, dots, underscores, or hyphen characters.
+
+Repository runner sets use the default runner group.
+
+## Auth fields
+
+Configure exactly one of `pat_token` or `github_app`. They are mutually exclusive.
 
 ### Personal Access Token
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `pat_token` | string | yes | GitHub PAT (must not be empty) |
+| Field | Type | Required | Rules |
+|---|---|---|---|
+| `pat_token` | string | yes | Nonempty |
 
-**Required PAT scopes:**
+For an organization scope, the token needs Organization Self hosted runners read and write access.
 
-For a **classic** token:
-- `admin:org` (Organization > Self-hosted runners: Read and write)
-- `repo` (for repository-level runners)
+For a repository scope, the token also needs repository Administration read and write access.
 
-For a **fine-grained** token:
-- **Resource owner**: your organization
-- **Organization permissions > Self-hosted runners**: Read and write
-- **Repository permissions > Administration**: Read and write (for repository-level runners)
+### GitHub App
 
-## Runner set configuration (`runner_sets[]`)
+| Field | Type | Required | Rules |
+|---|---|---|---|
+| `github_app.client_id` | string | yes | Nonempty |
+| `github_app.installation_id` | integer | yes | Greater than zero |
+| `github_app.private_key_path` | string | yes | Readable PEM private key file |
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `name` | string | yes | — | Runner set name (used as `runs-on` label in workflows). Must be unique across all orgs/repos |
-| `backend` | string | yes | — | Backend type: `tart` or `docker` |
-| `image` | string | no | — | VM image (Tart) or container image (Docker) |
-| `labels` | list | no | — | Runner labels |
-| `max_runners` | integer | yes | — | Maximum concurrent runners. Must be > 0 |
-| `platform` | string | no | — | Docker platform (e.g., `linux/arm64`, `linux/amd64`) |
+The private key PEM block type must contain `PRIVATE KEY`.
 
-### Backend: `tart`
+See [How to configure GitHub App authentication](/how-to/configure-github-app/) for the setup steps and permissions.
 
-For macOS VMs on Apple Silicon. Uses [Tart](https://tart.run) to create ephemeral VMs.
+## Runner set fields
 
-- `image`: OCI image reference (e.g., `ghcr.io/cirruslabs/macos-tahoe-xcode:26.3`)
-- `max_runners`: Recommend capping at 2 per host (Apple EULA restriction for macOS VMs)
-- Requires the `tart` CLI installed on the host
+Each `runner_sets[]` item supports:
 
-### Backend: `docker`
+| Field | Type | Required | Rules |
+|---|---|---|---|
+| `name` | string | yes | Nonempty and unique across the whole config |
+| `backend` | string | yes | `docker` or `tart` |
+| `image` | string | yes | Nonempty image reference |
+| `labels` | list of strings | no | GitHub runner labels |
+| `max_runners` | integer | yes | From 1 through 1000 |
+| `platform` | string | no | Backend specific |
 
-For Linux containers. Uses Docker-in-Docker.
+### Docker
 
-- `image`: Docker image with actions/runner (e.g., `ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner-dind:latest`)
-- `platform`: Specify for cross-architecture (e.g., `linux/amd64` for Rosetta 2 emulation on Apple Silicon)
-- Requires Docker installed and running on the host
+`platform` can be empty. When set, it must start with `linux/`, such as `linux/arm64` or `linux/amd64`.
 
-## Environment variables
+The image must contain the GitHub Actions runner and the tools needed by the workflow.
 
-Only one environment variable is supported:
+### Tart
 
-| Variable | Config file equivalent | Description |
-|----------|----------------------|-------------|
-| `LOG_LEVEL` | `log_level` | Overrides the log level from config file |
+`platform` must be empty. The image is a local or OCI Tart VM image.
 
-All other configuration must be done through the YAML config file.
+Tart requires Apple Silicon and the Tart CLI on the host.
 
-## Validation
+## CORS fields
 
-Startup, console validation, and console save use the same strict YAML validator. Unknown fields and duplicate keys are errors.
+The server applies these runtime defaults when a field is empty:
 
-Validation also checks runner set name uniqueness, auth choice, private key PEM data, API address, CORS values, writable paths, runner limits, and backend settings.
+| Field | Type | Runtime default | Rules |
+|---|---|---|---|
+| `allow_origin` | string | `*` | `*` or one valid origin URL |
+| `allow_methods` | string | `GET, POST, OPTIONS` | Only `GET`, `POST`, and `OPTIONS` |
+| `allow_headers` | string | `Content-Type, Connect-Protocol-Version, X-CSRF-Token` | One line |
+| `expose_headers` | string | `Connect-Protocol-Version` | One line |
+| `allow_credentials` | boolean | `false` | Requires a specific `allow_origin` when true |
+| `max_age` | integer | `0` | From 0 through 86400 seconds |
 
-GitHub connectivity is reported as a warning. It is not part of structural validation.
+Keep the Console on the same origin when possible. The daemon does not provide TLS.
 
-See [Use the operations console](/how-to/use-console/) for save, revision, and recovery behavior.
+## Path validation
+
+For `db_path`, `log_path`, and GitHub App private key paths, validation checks the local file system.
+
+* An existing file must be usable for its purpose.
+* A configured file path cannot name a directory.
+* An existing direct parent directory must be writable.
+* If the direct parent does not exist, its parent must exist.
+* `:memory:` is allowed for `db_path`.
+
+## Strict validation
+
+Startup, Console validation, and Console save use the same strict validator.
+
+Validation checks:
+
+* YAML structure
+* Known and duplicate fields
+* Required fields
+* Duration and number limits
+* GitHub owner and repository names
+* Global runner set name uniqueness
+* Auth method choice
+* Private key file and PEM data
+* Backend, image, and platform rules
+* API address
+* CORS values
+* Writable storage paths
+
+GitHub connectivity is not checked. Validation returns a warning for this limit.
+
+See [How to edit and activate config](/how-to/edit-config/) for the save flow.

--- a/doc-site/src/content/docs/reference/console.md
+++ b/doc-site/src/content/docs/reference/console.md
@@ -1,0 +1,93 @@
+---
+title: Console Reference
+description: Console pages, refresh behavior, config states, and security properties.
+---
+
+The Console is embedded in the daemon and manages one daemon on one host.
+
+The default address is `http://127.0.0.1:8080`.
+
+## Pages
+
+| Page | Data |
+|---|---|
+| Overview | Daemon uptime, GitHub connection, runner counts, job counts, config state, and current host use |
+| Jobs | Stored jobs, filters, pagination, detail, logs, resource samples, and GitHub Actions links |
+| Runner Sets | Configured scope, backend, image, labels, capacity, GitHub connection, and live runners |
+| Config | Active and disk identity, strict validation, editor, diff, restart commands, and ten revisions |
+| System | Build, platform, storage paths, storage size, current host use, and host history |
+
+## Normal refresh
+
+Overview, Jobs, Runner Sets, Config, System, and host history refresh every five seconds.
+
+The daemon checks the disk config every two seconds.
+
+A running job log requests new chunks every two seconds. A running job resource chart refreshes every five seconds.
+
+## Job filters
+
+Jobs supports:
+
+* Result
+* Runner set
+* Repository
+* Workflow
+* One hour, 24 hour, 7 day, or 30 day range
+
+The UI requests 50 jobs per page and uses a cursor for the next page.
+
+## Runner states
+
+| State | Meaning |
+|---|---|
+| `preparing` | Backend creation and runner registration are in progress |
+| `idle` | Runner is ready for work |
+| `busy` | Runner is running a job |
+
+Each runner set has its own GitHub connection state.
+
+## Job results
+
+The Console displays `running`, `success`, `failure`, or `canceled`.
+
+Job detail can contain queued, Scale Set assigned, runner assigned, started, and completed times. A field is `Unavailable` when GitHub did not provide it.
+
+## Config states
+
+| State | Meaning |
+|---|---|
+| **In sync** | Disk config matches active config |
+| **Restart required** | Valid disk config differs from active config |
+| **Disk config invalid** | Disk file is not usable. Active config is unchanged |
+
+Saving or restoring config writes disk only. The Console never restarts the service or hot reloads controllers.
+
+The daemon stores the newest ten full config revisions.
+
+## Admin and session
+
+The Console supports one local admin.
+
+* First setup requires a one time code from the local daemon log.
+* Password length is 12 through 256 characters.
+* Passwords are stored as bcrypt hashes.
+* A session lasts 24 hours.
+* Session cookies are HttpOnly and SameSite Strict.
+* Write calls require the session and a CSRF token.
+* Repeated failed sign in attempts are rate limited.
+* Password reset removes every active session.
+
+Config responses mask PAT values and do not return private key contents.
+
+## Network boundary
+
+The daemon does not provide TLS. Keep the default local address or place the service behind a trusted TLS reverse proxy.
+
+Do not expose the Console directly to the public internet.
+
+## Related guides
+
+* [Use the operations Console](/how-to/use-console/)
+* [How to edit and activate config](/how-to/edit-config/)
+* [How to recover config](/how-to/recover-config/)

--- a/doc-site/src/content/docs/reference/environment-variables.md
+++ b/doc-site/src/content/docs/reference/environment-variables.md
@@ -3,7 +3,7 @@ title: Environment Variables Reference
 description: Environment variables supported by elastic-fruit-runner.
 ---
 
-elastic-fruit-runner is primarily configured through its YAML config file. Only one environment variable is supported:
+Elastic Fruit Runner is configured through its YAML file. Only one environment variable is supported:
 
 | Variable | Config file equivalent | Description |
 |----------|----------------------|-------------|
@@ -15,4 +15,6 @@ elastic-fruit-runner is primarily configured through its YAML config file. Only 
 LOG_LEVEL=debug elastic-fruit-runner
 ```
 
-All other settings (orgs, repos, auth, runner sets, idle timeout) must be configured in the YAML config file. See the [configuration reference](/reference/configuration/) for details.
+`LOG_LEVEL` has higher priority than the YAML `log_level` field.
+
+All other settings must be configured in the YAML file. See [Configuration Reference](/reference/configuration/).

--- a/doc-site/src/content/docs/reference/history-and-storage.md
+++ b/doc-site/src/content/docs/reference/history-and-storage.md
@@ -1,0 +1,109 @@
+---
+title: History and Storage Reference
+description: Job logs, resource samples, accuracy, retention, and storage cleanup rules.
+---
+
+Job history, job logs, job resource samples, host samples, auth data, and config revisions use the configured SQLite database.
+
+## Collection intervals
+
+| Data | Interval |
+|---|---|
+| Running job log | Collected every two seconds |
+| Running job resource sample | Collected every five seconds |
+| Host resource sample | Collected every five seconds |
+| Host rollup | One row per minute |
+| Disk config state | Checked every two seconds |
+
+## Job history
+
+A job record can contain:
+
+* GitHub job ID and display name
+* Owner and repository
+* Workflow reference and run ID
+* Event and labels
+* Runner set, runner, and backend
+* Result
+* Queued, Scale Set assigned, runner assigned, started, and completed times
+* GitHub Actions URL
+
+Jobs are ordered from newest to oldest. The normal UI page size is 50. The storage layer accepts at most 200 jobs in one page request.
+
+## Job logs
+
+Logs are stored as ordered chunks with a sequence number and recorded time.
+
+The Console requests up to 500 chunks at a time. A sequence cursor prevents previously read chunks from being added twice.
+
+Job logs describe the runner process. GitHub Actions step output remains in GitHub.
+
+## Resource fields
+
+A resource sample can contain:
+
+* CPU percent
+* Memory used and available
+* Disk used and available
+* Disk read and write bytes
+* Network receive and send bytes
+* One minute load
+* Temperature
+
+Not every source provides every field.
+
+## Accuracy
+
+| Source | Accuracy | Meaning |
+|---|---|---|
+| Docker container stats | Exact | Values reported for the runner container |
+| Tart allocation | Estimate | VM memory and disk allocation, not exact guest use |
+| Host collector | Exact for the host source | Whole host values, not one runner |
+
+The UI marks estimated job data as **Tart host estimate**.
+
+## Host retention
+
+Five second host samples remain for 24 hours.
+
+One minute host rollups remain for 30 days.
+
+Queries inside the most recent 24 hours use five second samples. Older queries use one minute rollups.
+
+The System page reports the earliest host sample still available.
+
+## Job retention
+
+Completed job records, job logs, and job resource samples remain for up to 30 days.
+
+Running job data is not removed by retention cleanup.
+
+## Storage limit
+
+The SQLite database, its write ahead log, and its shared memory file are measured together.
+
+Cleanup runs after each minute rollup:
+
+1. Remove data older than 30 days.
+2. Measure current database storage.
+3. If storage is above 10 GiB, remove the oldest completed job data.
+4. Compact and measure again.
+5. Stop when storage is at or below 9 GiB or no completed job can be removed.
+
+Running jobs are never selected by the size cleanup.
+
+The daemon log file is shown separately on the System page. It is not part of the history database limit.
+
+## Storage paths
+
+`db_path` selects the SQLite file. The default is:
+
+```text
+~/.elastic-fruit-runner/jobs.db
+```
+
+The database file is set to mode `0600`.
+
+`log_path` optionally writes daemon JSON logs to a file. Empty `log_path` sends logs to standard output.
+
+See [Configuration Reference](/reference/configuration/) for path validation rules.

--- a/doc-site/src/content/docs/tutorials/getting-started.md
+++ b/doc-site/src/content/docs/tutorials/getting-started.md
@@ -33,13 +33,13 @@ You should see a version number.
 brew install boring-design/tap/elastic-fruit-runner
 ```
 
-Check the installed command:
+Check the installed path:
 
 ```sh
-elastic-fruit-runner --help
+command -v elastic-fruit-runner
 ```
 
-The command should print its available options.
+The command should print the Homebrew binary path.
 
 ## Create the config
 


### PR DESCRIPTION
## Problem

User reference did not cover the current Console, CORS defaults, storage rules, or password reset command. The sample config also differed from runtime CORS behavior.

## Solution

Document the current code defined behavior and update the sample config so it passes the strict validator.

## Major Changes

- Configuration and CLI reference
  - Document all YAML fields, limits, defaults, search paths, CORS behavior, and password reset
- Console reference
  - Document pages, states, refresh rules, auth, and network boundaries
- History and storage reference
  - Document sampling, accuracy, retention, and storage cleanup

Closes #99
Tracked by #94

## Validation

- `config.example.yaml` passes the current strict validator
- The complete Configuration Reference example passes the current strict validator
- `pnpm --dir doc-site build`
- `prek run --all-files`