### PR TITLE
docs: explain runner and console design

### DIFF
--- a/doc-site/src/content/docs/explanation/console-design.md
+++ b/doc-site/src/content/docs/explanation/console-design.md
@@ -1,0 +1,52 @@
+---
+title: Console design
+description: Why the Console is local, uses manual config activation, and keeps bounded history.
+---
+
+The Console is part of the Elastic Fruit Runner daemon. It is designed to operate one daemon on one host.
+
+This keeps setup small and lets the Console show the same runner state, job records, config state, and host data that the daemon already owns. It is not a shared control plane for a fleet.
+
+## Active config and disk config
+
+The active config is the copy loaded when the daemon started. The disk config is the current YAML file.
+
+Keeping these as separate identities makes changes visible without claiming that they are already active. The Console reports whether they match, whether a valid disk change needs a restart, or whether the disk file is invalid.
+
+Saving does not replace live controllers. Changing a scope, auth method, backend, image, or capacity can affect running jobs and GitHub connections. An automatic restart would choose an interruption time for the operator. The Console therefore writes the file and leaves activation to a manual service restart.
+
+See [How to edit and activate config](/how-to/edit-config/) for the task and [Console Reference](/reference/console/) for the states.
+
+## Revisions and config mode
+
+Each successful save creates a full config revision. A config loaded at normal startup is also marked as an active revision.
+
+If the disk file becomes invalid, the last active revision gives the daemon a known config that previously started. The daemon can keep runner service available while the operator repairs the disk file.
+
+If there is no active revision, the daemon cannot safely start runner controllers. It enters config mode instead. The Console and config editor remain available, but runner management does not start. This gives the operator a recovery path without pretending that an unknown config is active.
+
+Restoring a revision writes it to disk. It still needs a manual restart for the same reason as any other config change.
+
+See [How to recover config](/how-to/recover-config/) for both recovery cases.
+
+## Local single admin model
+
+The Console has one local admin because it manages one local daemon. It does not provide teams, roles, or an identity provider.
+
+The first start uses a one time setup code from the daemon log. The admin password is stored as a bcrypt hash. Sessions use an HttpOnly, SameSite Strict cookie, and write calls also need a CSRF token.
+
+These controls protect the application session. They do not create a safe public network boundary. The daemon has no built in TLS, so the Console should stay local or sit behind a trusted TLS reverse proxy.
+
+This model is simple for a local host, but it is not a replacement for a shared access system.
+
+## Samples, estimates, and retention
+
+Docker provides container stats, so Docker job charts describe the runner container. Tart currently provides virtual machine allocation from the host, not exact guest use, so the Console marks it as an estimate.
+
+Keeping that label matters more than filling every chart. An estimate can still show configured memory and disk capacity, but it should not be read as guest demand.
+
+Host data uses five second samples for recent investigation. One minute rollups keep longer trends with less storage. Raw data expires after 24 hours, while rollups and completed job history expire after 30 days.
+
+The database also has a size limit and protects running jobs from cleanup. These bounds keep local history useful without allowing it to grow forever on the runner host.
+
+See [History and Storage Reference](/reference/history-and-storage/) for the exact intervals, limits, and data sources.

--- a/doc-site/src/content/docs/explanation/runner-lifecycle.md
+++ b/doc-site/src/content/docs/explanation/runner-lifecycle.md
@@ -1,0 +1,57 @@
+---
+title: Runner lifecycle
+description: How GitHub assignments become short lived Docker containers or Tart virtual machines.
+---
+
+Elastic Fruit Runner separates the GitHub control flow from the backend resource flow.
+
+GitHub decides that a job belongs to a runner set. The daemon decides how many local runners to prepare, up to the configured capacity. Docker or Tart then creates the environment that runs the job.
+
+## Scope and Scale Set
+
+Each configured organization or repository is a GitHub scope. A runner set inside that scope defines labels, capacity, and a backend image.
+
+The daemon creates a Scale Set listener for each runner set. The listener receives the number of assigned jobs from GitHub. That number includes jobs waiting for a runner and jobs already running.
+
+The daemon compares assigned jobs with runners that are preparing, idle, or busy. It creates only the missing number and never goes above `max_runners`. Counting preparing runners prevents two updates from creating the same capacity twice.
+
+## Preparing
+
+A new runner first enters `preparing`.
+
+The daemon asks GitHub for a Just in Time runner config. It then creates a Docker container or Tart virtual machine and starts the GitHub Actions runner inside it.
+
+Preparation can include pulling an image, cloning and starting a virtual machine, or starting a container. The runner becomes idle only after the backend has started it.
+
+If preparation fails, the daemon removes the local resource and tries to remove the GitHub runner record. This cleanup is best effort because either side may already be unavailable.
+
+## Idle and running
+
+An idle runner waits for GitHub to assign one job.
+
+When GitHub reports that the job started, the daemon marks the runner as busy and records the job. While it runs, the daemon collects runner logs every two seconds and backend resource data every five seconds.
+
+The Just in Time config limits the runner to one job. It does not return to a shared idle pool after that job.
+
+An idle runner that receives no work before `idle_timeout` is also removed. This keeps unused containers and virtual machines from staying on the host.
+
+## Completed and cleanup
+
+When GitHub reports completion, the daemon records the result, marks the runner done, and starts backend cleanup.
+
+Docker cleanup removes the container. Tart cleanup stops and deletes the virtual machine. The job record, captured runner log, and resource samples remain in local history until retention removes them.
+
+This design separates two different facts:
+
+* GitHub job state describes the work.
+* Runner state describes the local environment that can accept or run work.
+
+A completed job can remain in history even though its runner no longer exists.
+
+## Shutdown
+
+During daemon shutdown, new preparation is canceled. Idle and busy local resources are cleaned up and their GitHub runner records are removed when possible.
+
+A service restart can therefore interrupt a running job. This is why config changes require an operator to choose the restart time instead of letting the Console restart the daemon.
+
+See [How to check runner capacity](/how-to/check-runner-capacity/) for the live states and [History and Storage Reference](/reference/history-and-storage/) for recorded data.

--- a/doc-site/src/content/docs/explanation/what-is-elastic-fruit-runner.md
+++ b/doc-site/src/content/docs/explanation/what-is-elastic-fruit-runner.md
@@ -1,54 +1,48 @@
 ---
-title: What is elastic-fruit-runner?
-description: Turn your Apple Silicon Mac into a multi-platform GitHub Actions runner farm.
+title: What is Elastic Fruit Runner?
+description: Why Elastic Fruit Runner uses one daemon to provide short lived GitHub Actions runners.
 ---
 
-**elastic-fruit-runner** is a daemon that turns a single Apple Silicon Mac into a multi-platform GitHub Actions runner farm. One machine simultaneously provides macOS arm64, Linux arm64, and Linux amd64 runners — automatically scaling up when jobs arrive and destroying them after completion.
+Elastic Fruit Runner is a daemon that turns one Apple Silicon Mac into a small GitHub Actions runner host.
 
-## The problems
+It can provide three common environments:
 
-### 1. Too many machine types, never enough runners
+| Environment | Backend |
+|---|---|
+| macOS arm64 | Tart virtual machine |
+| Linux arm64 | Docker container |
+| Linux amd64 | Docker container with host emulation |
 
-GitHub Actions workflows target a wide variety of platforms — macOS arm64 for iOS builds, Linux arm64 for ARM deployments, Linux amd64 for the rest. Traditionally, each platform needed its own dedicated machine or VM. If you wanted full coverage, you were looking at multiple machines or expensive GitHub-hosted runner minutes.
+## Why one host
 
-Thanks to Apple Silicon, that constraint is gone. A single Mac can natively run macOS arm64, Linux arm64 (via Docker), and Linux amd64 (via Docker + Rosetta 2). One machine, three platforms — you just need software that knows how to orchestrate them.
+Teams often need both macOS and Linux jobs, but a small team may not want a separate host or a Kubernetes cluster for each environment.
 
-### 2. Runner management is painful
+Apple Silicon can run macOS virtual machines and Linux containers on the same machine. Elastic Fruit Runner uses that ability while keeping the control plane in one local daemon.
 
-The traditional self-hosted runner experience is full of friction:
+The daemon can manage runner sets for GitHub organizations and repositories. Each runner set has its own backend, image, labels, and capacity.
 
-- **Per-repo and per-org registration** — every repository or organization needs its own runner registration. Managing tokens and runner entries across dozens of repos is tedious and error-prone.
-- **Always-on standby** — traditional runners must stay running 24/7, burning CPU and memory even when there are no jobs. You're paying the cost of idle infrastructure just to be ready.
-- **Stale runners and ghost entries** — when a runner crashes or a machine reboots, you end up with orphaned runner entries in GitHub that block the job queue until you manually clean them up.
+## Why short lived runners
 
-### 3. Existing solutions require Kubernetes
+A permanent self hosted runner keeps state from earlier jobs and needs manual care when it stops working.
 
-[actions-runner-controller (ARC)](https://github.com/actions/actions-runner-controller) is an excellent project that solved elastic runner scaling for Linux. But it requires Kubernetes. If you just have a Mac mini under your desk, the path to ARC looks like: install minikube (or kind, or k3s), then deploy ARC into the cluster, then manage Kubernetes on top of managing runners. Running a full Kubernetes stack on a Mac mini just to get elastic CI runners is absurd overkill.
+Elastic Fruit Runner creates a Just in Time runner when GitHub assigns work. The runner accepts one job, then its container or virtual machine is removed. This reduces shared state between jobs and allows an idle host to scale to zero runners.
 
-## The solution
+[Runner lifecycle](/explanation/runner-lifecycle/) explains this flow.
 
-elastic-fruit-runner throws all of that away. Install it on any Apple Silicon Mac and it becomes a multi-platform runner farm:
+## Why no Kubernetes
 
-| Runner type | Backend | How it works |
-|---|---|---|
-| **macOS arm64** | Tart | Ephemeral macOS VMs via Apple's Virtualization.framework |
-| **Linux arm64** | Docker | Native Linux containers on ARM |
-| **Linux amd64** | Docker | Linux containers via Rosetta 2 emulation |
+Kubernetes is useful when many machines and services need one shared control plane. It also adds a cluster that must be installed, secured, upgraded, and monitored.
 
-Powered by the official [GitHub Runner Scale Set API](https://github.com/actions/scaleset), elastic-fruit-runner fundamentally changes how self-hosted runners work:
+Elastic Fruit Runner is built for one host. A local daemon is a smaller operating model for that scope. It uses the GitHub Runner Scale Set service directly and manages Docker and Tart resources on the host.
 
-- **One daemon manages everything** — no per-repo registration, no per-org token juggling. Configure your orgs and repos in a single YAML file, and the daemon handles all scale set registration and lifecycle management.
-- **Scale to zero** — when there are no jobs, there are no runners. No idle VMs, no idle containers, no wasted resources. The daemon itself is a lightweight long-polling process that consumes almost nothing.
-- **Scale up on demand** — when a job arrives, the daemon instantly provisions an ephemeral runner (VM or container), runs the job, and destroys it. Each runner accepts exactly one job via JIT (Just-In-Time) tokens — no stale entries, no ghost runners.
-- **No Kubernetes required** — just `brew install` and a config file. That's it. No clusters, no operators, no YAML manifests.
+## Local operations
 
-## Who is it for?
+The embedded [Console](/reference/console/) shows runner capacity, jobs, host history, and config state for the same daemon. It is an operations view, not a central service for many hosts.
 
-- **Anyone with an Apple Silicon Mac** who wants to stop paying for GitHub Actions minutes
-- Teams running CI/CD for macOS or iOS projects who are tired of expensive GitHub-hosted macOS runners
-- Developers who need both macOS and Linux runners but don't want to manage Kubernetes or separate infrastructure
-- People whose Mac mini is sitting idle running nothing but openclaw and deserve a better purpose in life
+The Console follows a local, single admin security model. [Console design](/explanation/console-design/) describes the reasons and limits.
 
 ## Current status
 
-elastic-fruit-runner is a proof of concept. The core flow (job detection, VM provisioning, runner execution, cleanup) works reliably. It is not yet production-hardened — see the [roadmap](https://github.com/boring-design/elastic-fruit-runner) for planned improvements.
+Elastic Fruit Runner is a proof of concept. The main runner and Console flows work, but the project is not described as production ready.
+
+It fits people who can operate and secure one Apple Silicon host and who accept the current proof of concept limits. Review the [Getting Started tutorial](/tutorials/getting-started/) and current repository Roadmap before using it for important workloads.


### PR DESCRIPTION
## Problem

The user docs did not explain the runner lifecycle, config activation model, recovery design, or Console security and storage choices.

## Solution

Add focused explanation pages for the runner and Console, and replace old product text with the current proof of concept model.

## Major Changes

- Runner model
  - Explain Scale Sets, Just in Time runners, lifecycle states, and cleanup
- Console model
  - Explain manual config activation, revisions, config mode, local security, and bounded history
- Product overview
  - Describe current scope and proof of concept status without old Dashboard text

Closes #100
Tracked by #94

## Validation

- `pnpm --dir doc-site build`
- `prek run --all-files`