### PR TITLE
test: fix config integration fixtures

### DIFF
--- a/features/config/loading.feature
+++ b/features/config/loading.feature
@@ -21,7 +21,7 @@ Feature: Configuration loading
             github_app:
               client_id: Iv23li_test
               installation_id: 116416405
-              private_key_path: /path/to/key.pem
+              private_key_path: "TEST_PRIVATE_KEY_PATH"
           runner_group: MyGroup
           runner_sets:
             - name: efr-linux-arm64
@@ -62,6 +62,15 @@ Feature: Configuration loading
   Scenario: custom idle timeout duration
     Given a config file with content:
       """
+      repos:
+        - repo: boring-design/configtest
+          auth:
+            pat_token: testtoken
+          runner_sets:
+            - name: configtest
+              backend: docker
+              image: testimage:latest
+              max_runners: 1
       idle_timeout: 45m
       """
     When I load the configuration with that file
@@ -70,6 +79,15 @@ Feature: Configuration loading
   Scenario: log level from config file
     Given a config file with content:
       """
+      repos:
+        - repo: boring-design/configtest
+          auth:
+            pat_token: testtoken
+          runner_sets:
+            - name: configtest
+              backend: docker
+              image: testimage:latest
+              max_runners: 1
       log_level: debug
       """
     When I load the configuration with that file

--- a/test/integration/steps_test.go
+++ b/test/integration/steps_test.go
@@ -114,8 +114,17 @@ func initializeScenario(sc *godog.ScenarioContext) {
 		if state.tempDir == "" {
 			state.tempDir, _ = os.MkdirTemp("", "efr-bdd-*")
 		}
+		configText := content.Content
+		if strings.Contains(configText, "TEST_PRIVATE_KEY_PATH") {
+			privateKeyPath := filepath.Join(state.tempDir, "private_key.pem")
+			privateKey := []byte("-----BEGIN PRIVATE KEY-----\ndGVzdA==\n-----END PRIVATE KEY-----\n")
+			if err := os.WriteFile(privateKeyPath, privateKey, 0o600); err != nil {
+				return fmt.Errorf("write test private key %s: %w", privateKeyPath, err)
+			}
+			configText = strings.ReplaceAll(configText, "TEST_PRIVATE_KEY_PATH", privateKeyPath)
+		}
 		state.configFile = filepath.Join(state.tempDir, "config.yaml")
-		return os.WriteFile(state.configFile, []byte(content.Content), 0o644)
+		return os.WriteFile(state.configFile, []byte(configText), 0o644)
 	})
 
 	sc.Step(`^the environment variable "([^"]*)" is set to "([^"]*)"$`, func(key, value string) {


### PR DESCRIPTION
## Problem

Strict config validation rejects three integration fixtures because they use incomplete config or a missing private key file.

## Solution

Update the fixtures to meet current validation rules. Create a temporary PEM key inside the integration test directory.

## Major Changes

- Config loading scenarios
  - Add valid repo and runner set data to partial config fixtures
- GitHub App fixture
  - Replace the missing key path with a temporary test PEM file